### PR TITLE
Add configuration option for Redis sentinels

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -41,12 +41,12 @@ func ConfigSpec(c gospec.Context) {
 		c.Expect(Config.processId, Equals, "2")
 	})
 
-	c.Specify("requires a server parameter", func() {
+	c.Specify("requires a server or sentinel parameter", func() {
 		err := recoverOnPanic(func() {
 			Configure(map[string]string{"process": "2"})
 		})
 
-		c.Expect(err, Equals, "Configure requires a 'server' option, which identifies a Redis instance")
+		c.Expect(err, Equals, "Configure requires a 'server' or 'sentinels' options, which identify either Redis instance or sentinels.")
 	})
 
 	c.Specify("requires a process parameter", func() {
@@ -86,5 +86,15 @@ func ConfigSpec(c gospec.Context) {
 		})
 
 		c.Expect(Config.PollInterval, Equals, 1)
+	})
+
+	c.Specify("configure sentinels", func() {
+		Configure(map[string]string{
+			"sentinels":     "localhost:26379,localhost:46379",
+			"process":       "1",
+			"poll_interval": "1",
+		})
+
+		c.Expect(Config.Client.Options().Addr, Equals, "FailoverClient")
 	})
 }


### PR DESCRIPTION
Add configuration option for Redis sentinels; the Redis client can be configured to work with either single Redis server or Redis sentinels.