### PR TITLE
Use `lpush` to add new messages to a queue

### DIFF
--- a/enqueue.go
+++ b/enqueue.go
@@ -79,7 +79,7 @@ func EnqueueWithOptions(queue, class string, args interface{}, opts EnqueueOptio
 		return "", err
 	}
 	queue = Config.Namespace + "queue:" + queue
-	_, err = rc.RPush(queue, bytes).Result()
+	_, err = rc.LPush(queue, bytes).Result()
 	if err != nil {
 		return "", err
 	}

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -103,3 +103,36 @@ func TestEnqueueIn(t *testing.T) {
 
 	rc.Del(scheduleQueue)
 }
+
+func TestMultipleEnqueueOrder(t *testing.T) {
+	namespace := "prod"
+	setupTestConfigWithNamespace(namespace)
+	rc := Config.Client
+
+	var msg1, _ = NewMsg("{\"key\":\"1\"}")
+	_, err := Enqueue("testq1", "Compare", msg1.ToJson())
+	assert.Nil(t, err)
+
+	var msg2, _ = NewMsg("{\"key\":\"2\"}")
+	_, err = Enqueue("testq1", "Compare", msg2.ToJson())
+	assert.Nil(t, err)
+
+	len, _ := rc.LLen("prod:queue:testq1").Result()
+	assert.Equal(t, int64(2), len)
+
+	bytesMsg, err := rc.RPop("prod:queue:testq1").Result()
+	assert.Nil(t, err)
+	var data EnqueueData
+	json.Unmarshal([]byte(bytesMsg), &data)
+	actualMsg, err := NewMsg(data.Args.(string))
+	assert.Equal(t, msg1.Get("key"), actualMsg.Get("key"))
+
+	bytesMsg, err = rc.RPop("prod:queue:testq1").Result()
+	assert.Nil(t, err)
+	json.Unmarshal([]byte(bytesMsg), &data)
+	actualMsg, err = NewMsg(data.Args.(string))
+	assert.Equal(t, msg2.Get("key"), actualMsg.Get("key"))
+
+	len, _ = rc.LLen("prod:queue:testq1").Result()
+	assert.Equal(t, int64(0), len)
+}


### PR DESCRIPTION
Use `lpush` to add new messages to a queue since the fetcher uses `rpop` to get messages from the queue.  This ensures fifo order of processing of messages.
    
The code before this fix would result in filo order of processing. Also, this makes the library consistent with sidekiq: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/client.rb#L205