### PR TITLE
Use return errors as primary method of conveying job failure

### DIFF
--- a/job.go
+++ b/job.go
@@ -1,3 +1,3 @@
 package workers
 
-type jobFunc func(message *Msg)
+type JobFunc func(message *Msg) error

--- a/manager.go
+++ b/manager.go
@@ -8,7 +8,7 @@ import (
 type manager struct {
 	queue       string
 	fetch       Fetcher
-	job         jobFunc
+	job         JobFunc
 	concurrency int
 	workers     []*worker
 	workersM    *sync.Mutex
@@ -93,7 +93,7 @@ func (m *manager) reset() {
 	m.fetch = Config.Fetch(m.queue)
 }
 
-func newManager(queue string, job jobFunc, concurrency int, mids ...Action) *manager {
+func newManager(queue string, job JobFunc, concurrency int, mids ...Action) *manager {
 	var customMids *Middlewares
 	if len(mids) == 0 {
 		customMids = Middleware

--- a/middleware_logging.go
+++ b/middleware_logging.go
@@ -8,7 +8,15 @@ import (
 
 type MiddlewareLogging struct{}
 
-func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() bool) (acknowledge bool) {
+func (l *MiddlewareLogging) procesError(prefix string, start time.Time, err error) {
+	Logger.Println(prefix, "fail:", time.Since(start))
+
+	buf := make([]byte, 4096)
+	buf = buf[:runtime.Stack(buf, false)]
+	Logger.Printf("%s error: %v\n%s", prefix, err, buf)
+}
+
+func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() error) (err error) {
 	prefix := fmt.Sprint(queue, " JID-", message.Jid())
 
 	start := time.Now()
@@ -17,19 +25,24 @@ func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() bool) (
 
 	defer func() {
 		if e := recover(); e != nil {
-			Logger.Println(prefix, "fail:", time.Since(start))
+			var ok bool
+			if err, ok = e.(error); !ok {
+				err = fmt.Errorf("%v", e)
+			}
 
-			buf := make([]byte, 4096)
-			buf = buf[:runtime.Stack(buf, false)]
-			Logger.Printf("%s error: %v\n%s", prefix, e, buf)
-
-			panic(e)
+			if err != nil {
+				l.procesError(prefix, start, err)
+			}
 		}
+
 	}()
 
-	acknowledge = next()
-
-	Logger.Println(prefix, "done:", time.Since(start))
+	err = next()
+	if err != nil {
+		l.procesError(prefix, start, err)
+	} else {
+		Logger.Println(prefix, "done:", time.Since(start))
+	}
 
 	return
 }

--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -16,40 +16,56 @@ const (
 
 type MiddlewareRetry struct{}
 
-func (r *MiddlewareRetry) Call(queue string, message *Msg, next func() bool) (acknowledge bool) {
+func (r *MiddlewareRetry) processError(queue string, message *Msg, err error) error {
+	if retry(message) {
+		message.Set("queue", queue)
+		message.Set("error_message", fmt.Sprintf("%v", err))
+		retryCount := incrementRetry(message)
+
+		waitDuration := durationToSecondsWithNanoPrecision(
+			time.Duration(
+				secondsToDelay(retryCount),
+			) * time.Second,
+		)
+
+		rc := Config.Client
+		_, rcErr := rc.ZAdd(Config.Namespace+RETRY_KEY, redis.Z{
+			Score:  nowToSecondsWithNanoPrecision() + waitDuration,
+			Member: message.ToJson(),
+		}).Result()
+
+		// If we can't add the job to the retry queue,
+		// then we shouldn't acknowledge the job, otherwise
+		// it'll disappear into the void.
+		if rcErr != nil {
+			return NoAckError{rcErr}
+		} else {
+			return nil
+		}
+	} else {
+		return err
+	}
+}
+
+func (r *MiddlewareRetry) Call(queue string, message *Msg, next func() error) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			rc := Config.Client
-
-			if retry(message) {
-				message.Set("queue", queue)
-				message.Set("error_message", fmt.Sprintf("%v", e))
-				retryCount := incrementRetry(message)
-
-				waitDuration := durationToSecondsWithNanoPrecision(
-					time.Duration(
-						secondsToDelay(retryCount),
-					) * time.Second,
-				)
-
-				_, err := rc.ZAdd(Config.Namespace+RETRY_KEY, redis.Z{
-					Score:  nowToSecondsWithNanoPrecision() + waitDuration,
-					Member: message.ToJson(),
-				}).Result()
-
-				// If we can't add the job to the retry queue,
-				// then we shouldn't acknowledge the job, otherwise
-				// it'll disappear into the void.
-				if err != nil {
-					acknowledge = false
-				}
+			var ok bool
+			if err, ok = e.(error); !ok {
+				err = fmt.Errorf("%v", e)
 			}
 
-			panic(e)
+			if err != nil {
+				err = r.processError(queue, message, err)
+			}
 		}
+
 	}()
 
-	acknowledge = next()
+	err = next()
+	if err != nil {
+		err = r.processError(queue, message, err)
+	}
 
 	return
 }

--- a/middleware_stats_test.go
+++ b/middleware_stats_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -22,9 +23,11 @@ func TestProcessedStats(t *testing.T) {
 	dayCountInt, _ := strconv.ParseInt(dayCount, 10, 64)
 	assert.Equal(t, int64(0), dayCountInt)
 
-	var job = (func(message *Msg) {
+	var job = (func(message *Msg) error {
 		// noop
+		return nil
 	})
+
 	manager := newManager("myqueue", job, 1)
 	worker := newWorker(manager)
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true}")
@@ -46,8 +49,8 @@ func TestFailedStats(t *testing.T) {
 	namespace := "prod"
 	setupTestConfigWithNamespace(namespace)
 
-	var job = (func(message *Msg) {
-		panic("AHHHH")
+	var job = (func(message *Msg) error {
+		panic(errors.New("AHHHH"))
 	})
 
 	manager := newManager("myqueue", job, 1)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -25,14 +25,14 @@ var order = make([]string, 0)
 type m1 struct{}
 type m2 struct{}
 
-func (m *m1) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (m *m1) Call(queue string, message *Msg, next func() error) (result error) {
 	order = append(order, "m1 enter")
 	result = next()
 	order = append(order, "m1 leave")
 	return
 }
 
-func (m *m2) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (m *m2) Call(queue string, message *Msg, next func() error) (result error) {
 	order = append(order, "m2 enter")
 	result = next()
 	order = append(order, "m2 leave")
@@ -59,8 +59,9 @@ func TestAppendMiddleware(t *testing.T) {
 	middleware.Append(first)
 	middleware.Append(second)
 
-	middleware.call("myqueue", message, func() {
+	middleware.call("myqueue", message, func() error {
 		order = append(order, "job")
+		return nil
 	})
 
 	expectedOrder := []string{
@@ -84,8 +85,9 @@ func TestPrependMiddleware(t *testing.T) {
 	middleware.Prepend(first)
 	middleware.Prepend(second)
 
-	middleware.call("myqueue", message, func() {
+	middleware.call("myqueue", message, func() error {
 		order = append(order, "job")
+		return nil
 	})
 
 	expectedOrder := []string{

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,6 +1,7 @@
 package workers
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -12,17 +13,17 @@ var failMiddlewareCalled bool
 
 type testMiddleware struct{}
 
-func (l *testMiddleware) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (l *testMiddleware) Call(queue string, message *Msg, next func() error) (result error) {
 	testMiddlewareCalled = true
 	return next()
 }
 
 type failMiddleware struct{}
 
-func (l *failMiddleware) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (l *failMiddleware) Call(queue string, message *Msg, next func() error) (result error) {
 	failMiddlewareCalled = true
 	next()
-	return false
+	return NoAckError{errors.New("test error")}
 }
 
 func confirm(manager *manager) (msg *Msg) {
@@ -40,8 +41,9 @@ func TestNewWorker(t *testing.T) {
 	setupTestConfig()
 	var processed = make(chan *Args)
 
-	var testJob = (func(message *Msg) {
+	var testJob = (func(message *Msg) error {
 		processed <- message.Args()
+		return nil
 	})
 
 	manager := newManager("myqueue", testJob, 1)
@@ -55,8 +57,9 @@ func TestWork(t *testing.T) {
 
 	var processed = make(chan *Args)
 
-	var testJob = (func(message *Msg) {
+	var testJob = (func(message *Msg) error {
 		processed <- message.Args()
+		return nil
 	})
 
 	manager := newManager("myqueue", testJob, 1)
@@ -110,8 +113,9 @@ func TestFailMiddleware(t *testing.T) {
 	setupTestConfig()
 
 	var processed = make(chan *Args)
-	var testJob = (func(message *Msg) {
+	var testJob = (func(message *Msg) error {
 		processed <- message.Args()
+		return nil
 	})
 
 	Middleware = NewMiddleware(
@@ -144,19 +148,41 @@ func TestFailMiddleware(t *testing.T) {
 	)
 }
 
-func TestRecover(t *testing.T) {
+func TestRecoverWithPanic(t *testing.T) {
 	setupTestConfig()
 
 	//recovers and confirms if job panics
-	var panicJob = (func(message *Msg) {
-		panic("AHHHHHHHHH")
+	var panicJob = (func(message *Msg) error {
+		panic(errors.New("AHHHHHHHHH"))
 	})
 
 	manager := newManager("myqueue", panicJob, 1)
 	worker := newWorker(manager)
 
 	messages := make(chan *Msg)
-	message, _ := NewMsg("{\"jid\":\"2309823\",\"args\":[\"foo\",\"bar\"]}")
+	message, _ := NewMsg("{\"jid\":\"2309823\",\"args\":[\"foo\",\"bar\"],\"retry\":true}")
+
+	go worker.work(messages)
+	messages <- message
+
+	assert.Equal(t, message, confirm(manager))
+
+	worker.quit()
+}
+
+func TestRecoverWithError(t *testing.T) {
+	setupTestConfig()
+
+	//recovers and confirms if job panics
+	var panicJob = (func(message *Msg) error {
+		return errors.New("AHHHHHHHHH")
+	})
+
+	manager := newManager("myqueue", panicJob, 1)
+	worker := newWorker(manager)
+
+	messages := make(chan *Msg)
+	message, _ := NewMsg("{\"jid\":\"2309823\",\"args\":[\"foo\",\"bar\"],\"retry\":true}")
 
 	go worker.work(messages)
 	messages <- message

--- a/workers.go
+++ b/workers.go
@@ -28,7 +28,7 @@ var Middleware = NewMiddleware(
 	&MiddlewareStats{},
 )
 
-func Process(queue string, job jobFunc, concurrency int, mids ...Action) {
+func Process(queue string, job JobFunc, concurrency int, mids ...Action) {
 	access.Lock()
 	defer access.Unlock()
 

--- a/workers_test.go
+++ b/workers_test.go
@@ -9,8 +9,9 @@ import (
 
 var called chan bool
 
-func myJob(message *Msg) {
+func myJob(message *Msg) error {
 	called <- true
+	return nil
 }
 
 func TestWorkers(t *testing.T) {


### PR DESCRIPTION
Update job processing to use return errors as primary method of conveying failure.

The existing behavior of panic & recover is in unchanged. Rather than use panic & recover exclusively also allow return errors.