### PR TITLE
Refactor and simplify middleware code

### DIFF
--- a/job.go
+++ b/job.go
@@ -1,3 +1,0 @@
-package workers
-
-type JobFunc func(message *Msg) error

--- a/middleware_retry_test.go
+++ b/middleware_retry_test.go
@@ -12,9 +12,7 @@ var panicingJob = (func(message *Msg) error {
 	panic(errors.New("AHHHH"))
 })
 
-var wares = NewMiddleware(
-	&MiddlewareRetry{},
-)
+var wares = NewMiddlewares(RetryMiddleware)
 
 func TestRetryQueue(t *testing.T) {
 	setupTestConfigWithNamespace("prod")
@@ -24,10 +22,10 @@ func TestRetryQueue(t *testing.T) {
 	//puts messages in retry queue when they fail
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -43,10 +41,10 @@ func TestDisableRetries(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":false}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -61,10 +59,10 @@ func TestNoDefaultRetry(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\"}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -79,10 +77,10 @@ func TestNumericRetries(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":5}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -97,10 +95,10 @@ func TestHandleNewFailedMessages(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -133,10 +131,10 @@ func TestRecurringFailedMessages(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true,\"queue\":\"default\",\"error_message\":\"bam\",\"failed_at\":\"2013-07-20 14:03:42 UTC\",\"retry_count\":10}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -165,10 +163,10 @@ func TestRecurringFailedMessagesWithMax(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":10,\"queue\":\"default\",\"error_message\":\"bam\",\"failed_at\":\"2013-07-20 14:03:42 UTC\",\"retry_count\":8}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -196,10 +194,10 @@ func TestRetryOnlyToMax(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true,\"retry_count\":25}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 
@@ -215,10 +213,10 @@ func TestRetryOnlyToCustomMax(t *testing.T) {
 
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":3,\"retry_count\":3}")
 
-	wares.call("myqueue", message, func() error {
+	wares.build("myqueue", func(message *Msg) error {
 		worker.process(message)
 		return nil
-	})
+	})(message)
 
 	rc := Config.Client
 

--- a/worker.go
+++ b/worker.go
@@ -73,9 +73,7 @@ func (w *worker) process(message *Msg) (err error) {
 		}
 	}()
 
-	return w.manager.mids.call(w.manager.queueName(), message, func() error {
-		return w.manager.job(message)
-	})
+	return w.manager.handler(message)
 }
 
 func (w *worker) processing() bool {

--- a/workers.go
+++ b/workers.go
@@ -22,13 +22,7 @@ var control = make(map[string]chan string)
 var access sync.Mutex
 var started bool
 
-var Middleware = NewMiddleware(
-	&MiddlewareLogging{},
-	&MiddlewareRetry{},
-	&MiddlewareStats{},
-)
-
-func Process(queue string, job JobFunc, concurrency int, mids ...Action) {
+func Process(queue string, job JobFunc, concurrency int, mids ...MiddlewareFunc) {
 	access.Lock()
 	defer access.Unlock()
 


### PR DESCRIPTION
Simplify the handling/calling of middlewares by composing the middleware
functions together instead of looping through an array to call them.
Managers now only need to store a single `JobFunc`, which will call all middlewares
provided when the manager was created.

The behavior for setting up a worker with custom middlewares is also changed:
If custom middlewares are provided, the default middlewares are not
included. The old behavior can be obtained with
`DefaultMiddlewares().Append(customMid)`. Additionally, a new
`NopMiddleware` can be provided if removing the default middlewares is
desired.