### PR TITLE
Move message ack behavior onto Msg struct

### DIFF
--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -36,7 +36,7 @@ func retryProcessError(queue string, message *Msg, err error) error {
 		// then we shouldn't acknowledge the job, otherwise
 		// it'll disappear into the void.
 		if err != nil {
-			err = NoAckError{err}
+			message.ack = false
 		}
 	}
 	return err

--- a/msg.go
+++ b/msg.go
@@ -12,6 +12,7 @@ type data struct {
 type Msg struct {
 	*data
 	original string
+	ack      bool
 }
 
 type Args struct {
@@ -54,7 +55,7 @@ func NewMsg(content string) (*Msg, error) {
 	if d, err := newData(content); err != nil {
 		return nil, err
 	} else {
-		return &Msg{d, content}, nil
+		return &Msg{d, content, true}, nil
 	}
 }
 

--- a/worker.go
+++ b/worker.go
@@ -14,10 +14,6 @@ type worker struct {
 	startedAt  int64
 }
 
-type NoAckError struct {
-	error
-}
-
 func (w *worker) start() {
 	go w.work(w.manager.fetch.Messages())
 }
@@ -34,11 +30,9 @@ func (w *worker) work(messages chan *Msg) {
 			atomic.StoreInt64(&w.startedAt, time.Now().UTC().Unix())
 			w.currentMsg = message
 
-			err := w.process(message)
+			w.process(message)
 
-			if err == nil {
-				w.manager.confirm <- message
-			} else if _, ok := err.(NoAckError); !ok {
+			if message.ack {
 				w.manager.confirm <- message
 			}
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -22,7 +22,8 @@ func failMiddleware(queue string, next JobFunc) JobFunc {
 	return func(message *Msg) error {
 		failMiddlewareCalled = true
 		next(message)
-		return NoAckError{errors.New("test error")}
+		message.ack = false
+		return errors.New("test error")
 	}
 }
 


### PR DESCRIPTION
Instead of wrapping errors, which is prone to issues if custom middlewares are used (a prepended middleware might also wrap the error), keep track of whether a `Msg` should be acked with a field on the struct.