### PR TITLE
Make Configure take an Options struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ func myMiddleware(queue string, next JobFunc) JobFunc {
 }
 
 func main() {
-  workers.Configure(map[string]string{
+  workers.Configure(Options{
     // location of redis instance
-    "server":  "localhost:6379",
+    ServerAddr: "localhost:6379",
     // instance of the database
-    "database":  "0",
+    Database:   0,
     // number of connections to keep open with redis
-    "pool":    "30",
+    PoolSize:   30,
     // unique process id for this instance of workers (for proper recovery of inprogress jobs on crash)
-    "process": "1",
+    ProcessID:  "1",
   })
 
   // create a middleware chain with the default middlewares, and append myMiddleware

--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -1,11 +1,11 @@
 package workers
 
 func setupTestConfig() {
-	Configure(map[string]string{
-		"server":   "localhost:6379",
-		"process":  "1",
-		"database": "15",
-		"pool":     "1",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
+		Database:   15,
+		PoolSize:   1,
 	})
 
 	rc := Config.Client
@@ -13,12 +13,12 @@ func setupTestConfig() {
 }
 
 func setupTestConfigWithNamespace(namespace string) {
-	Configure(map[string]string{
-		"server":    "localhost:6379",
-		"process":   "1",
-		"database":  "15",
-		"pool":      "1",
-		"namespace": namespace,
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
+		Database:   15,
+		PoolSize:   1,
+		Namespace:  namespace,
 	})
 
 	rc := Config.Client

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package workers
 
 import (
-	"strconv"
+	"errors"
 	"strings"
 	"time"
 
@@ -16,82 +16,67 @@ type config struct {
 	Fetch        func(queue string) Fetcher
 }
 
+type Options struct {
+	ProcessID    string
+	Namespace    string
+	PollInterval int
+	Database     int
+	Password     string
+	PoolSize     int
+
+	// Provide one of ServerAddr or SentinelAddrs
+	ServerAddr    string
+	SentinelAddrs string
+}
+
 var Config *config
 
-func Configure(options map[string]string) {
-	var namespace string
-	var pollInterval int
-
-	if options["process"] == "" {
-		panic("Configure requires a 'process' option, which uniquely identifies this instance")
+func Configure(options Options) error {
+	if options.ProcessID == "" {
+		return errors.New("Configure requires a ProcessID, which uniquely identifies this instance")
 	}
 
-	if options["namespace"] != "" {
-		namespace = options["namespace"] + ":"
+	if options.Namespace != "" {
+		options.Namespace += ":"
 	}
-	if seconds, err := strconv.Atoi(options["poll_interval"]); err == nil {
-		pollInterval = seconds
-	} else {
-		pollInterval = 15
+	if options.PoolSize == 0 {
+		options.PoolSize = 1
 	}
-
-	var redisDB int
-	if options["database"] != "" {
-		dbNum, err := strconv.Atoi(options["database"])
-		if err != nil {
-			panic("Incorrect database number provided.")
-		}
-		redisDB = dbNum
-	} else {
-		redisDB = 0
+	if options.PollInterval <= 0 {
+		options.PollInterval = 15
 	}
-
-	var redisPassword string
-	if options["password"] != "" {
-		redisPassword = options["password"]
-	}
-
-	if options["pool"] == "" {
-		options["pool"] = "1"
-	}
-	redisPoolSize, _ := strconv.Atoi(options["pool"])
 
 	redisIdleTimeout := 240 * time.Second
 
 	var rc *redis.Client
-	if options["server"] != "" {
-		redisOptions := &redis.Options{
+	if options.ServerAddr != "" {
+		rc = redis.NewClient(&redis.Options{
 			IdleTimeout: redisIdleTimeout,
-			Password:    redisPassword,
-			DB:          redisDB,
-			PoolSize:    redisPoolSize,
-		}
-
-		redisOptions.Addr = options["server"]
-
-		rc = redis.NewClient(redisOptions)
-	} else if options["sentinels"] != "" {
-		redisOptions := &redis.FailoverOptions{
-			IdleTimeout: redisIdleTimeout,
-			Password:    redisPassword,
-			DB:          redisDB,
-			PoolSize:    redisPoolSize,
-		}
-
-		redisOptions.SentinelAddrs = strings.Split(options["sentinels"], ",")
-
-		rc = redis.NewFailoverClient(redisOptions)
+			Password:    options.Password,
+			DB:          options.Database,
+			PoolSize:    options.PoolSize,
+			Addr:        options.ServerAddr,
+		})
+	} else if options.SentinelAddrs != "" {
+		rc = redis.NewFailoverClient(&redis.FailoverOptions{
+			IdleTimeout:   redisIdleTimeout,
+			Password:      options.Password,
+			DB:            options.Database,
+			PoolSize:      options.PoolSize,
+			SentinelAddrs: strings.Split(options.SentinelAddrs, ","),
+		})
 	} else {
-		panic("Configure requires a 'server' or 'sentinels' options, which identify either Redis instance or sentinels.")
+		return errors.New("Configure requires either the Server or Sentinels option")
 	}
 
 	Config = &config{
-		processId:    options["process"],
-		Namespace:    namespace,
-		PollInterval: pollInterval,
+		processId:    options.ProcessID,
+		Namespace:    options.Namespace,
+		PollInterval: options.PollInterval,
 		Client:       rc,
 		Fetch: func(queue string) Fetcher {
 			return NewFetch(queue, make(chan *Msg), make(chan bool))
 		},
 	}
+	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -25,88 +25,84 @@ var recoverOnPanic = func(f func()) (err error) {
 
 func TestRedisPoolConfig(t *testing.T) {
 	// Tests redis pool size which defaults to 1
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "2",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "2",
 	})
 	assert.Equal(t, 1, Config.Client.Options().PoolSize)
 
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "1",
-		"pool":    "20",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
+		PoolSize:   20,
 	})
 
 	assert.Equal(t, 20, Config.Client.Options().PoolSize)
 }
 
 func TestCustomProcessConfig(t *testing.T) {
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "1",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
 	})
 	assert.Equal(t, "1", Config.processId)
 
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "2",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "2",
 	})
 	assert.Equal(t, "2", Config.processId)
 }
 
 func TestRequiresRedisConfig(t *testing.T) {
-	err := recoverOnPanic(func() {
-		Configure(map[string]string{"process": "2"})
-	})
+	err := Configure(Options{ProcessID: "2"})
 
-	assert.Error(t, err, "Configure requires a 'server' or 'sentinels' options, which identify either Redis instance or sentinels.")
+	assert.Error(t, err, "Configure requires either the Server or Sentinels option")
 }
 
 func TestRequiresProcessConfig(t *testing.T) {
-	err := recoverOnPanic(func() {
-		Configure(map[string]string{"server": "localhost:6379"})
-	})
+	err := Configure(Options{ServerAddr: "localhost:6379"})
 
-	assert.Error(t, err, "Configure requires a 'process' option, which uniquely identifies this instance")
+	assert.Error(t, err, "Configure requires a ProcessID, which uniquely identifies this instance")
 }
 
 func TestAddsColonToNamespace(t *testing.T) {
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "1",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
 	})
 	assert.Equal(t, "", Config.Namespace)
 
-	Configure(map[string]string{
-		"server":    "localhost:6379",
-		"process":   "1",
-		"namespace": "prod",
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
+		Namespace:  "prod",
 	})
 	assert.Equal(t, "prod:", Config.Namespace)
 }
 
-func TestDefaultPoolIntervalConfig(t *testing.T) {
-	Configure(map[string]string{
-		"server":  "localhost:6379",
-		"process": "1",
+func TestDefaultPollIntervalConfig(t *testing.T) {
+	Configure(Options{
+		ServerAddr: "localhost:6379",
+		ProcessID:  "1",
 	})
 
 	assert.Equal(t, 15, Config.PollInterval)
 
-	Configure(map[string]string{
-		"server":        "localhost:6379",
-		"process":       "1",
-		"poll_interval": "1",
+	Configure(Options{
+		ServerAddr:   "localhost:6379",
+		ProcessID:    "1",
+		PollInterval: 1,
 	})
 
 	assert.Equal(t, 1, Config.PollInterval)
 }
 
 func TestSentinelConfig(t *testing.T) {
-	Configure(map[string]string{
-		"sentinels":     "localhost:26379,localhost:46379",
-		"process":       "1",
-		"poll_interval": "1",
+	Configure(Options{
+		SentinelAddrs: "localhost:26379,localhost:46379",
+		ProcessID:     "1",
+		PollInterval:  1,
 	})
 
 	assert.Equal(t, "FailoverClient", Config.Client.Options().Addr)


### PR DESCRIPTION
Having the main configuration function take a `map[string]string` makes it very difficult to tell what parameters are supported. Change the function to take an `Options` struct, to make it clear what options exist and what the configuration value for them should look like.

Additionally, remove more instances of panics being used to indicate failure.