### PR TITLE
Required Redis master name configuration for Sentinel client setup

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -1,56 +1,46 @@
 package workers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-var recoverOnPanic = func(f func()) (err error) {
-	defer func() {
-		if cause := recover(); cause != nil {
-			var ok bool
-			err, ok = cause.(error)
-			if !ok {
-				err = fmt.Errorf("not error; %v", cause)
-			}
-		}
-	}()
-
-	f()
-
-	return
-}
-
 func TestRedisPoolConfig(t *testing.T) {
 	// Tests redis pool size which defaults to 1
-	Configure(Options{
+	err := Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "2",
 	})
+
+	assert.NoError(t, err)
 	assert.Equal(t, 1, Config.Client.Options().PoolSize)
 
-	Configure(Options{
+	err = Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "1",
 		PoolSize:   20,
 	})
 
+	assert.NoError(t, err)
 	assert.Equal(t, 20, Config.Client.Options().PoolSize)
 }
 
 func TestCustomProcessConfig(t *testing.T) {
-	Configure(Options{
+	err := Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "1",
 	})
+
+	assert.NoError(t, err)
 	assert.Equal(t, "1", Config.processId)
 
-	Configure(Options{
+	err = Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "2",
 	})
+
+	assert.NoError(t, err)
 	assert.Equal(t, "2", Config.processId)
 }
 
@@ -67,43 +57,61 @@ func TestRequiresProcessConfig(t *testing.T) {
 }
 
 func TestAddsColonToNamespace(t *testing.T) {
-	Configure(Options{
+	err := Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "1",
 	})
+
+	assert.NoError(t, err)
 	assert.Equal(t, "", Config.Namespace)
 
-	Configure(Options{
+	err = Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "1",
 		Namespace:  "prod",
 	})
+
+	assert.NoError(t, err)
 	assert.Equal(t, "prod:", Config.Namespace)
 }
 
 func TestDefaultPollIntervalConfig(t *testing.T) {
-	Configure(Options{
+	err := Configure(Options{
 		ServerAddr: "localhost:6379",
 		ProcessID:  "1",
 	})
 
+	assert.NoError(t, err)
 	assert.Equal(t, 15, Config.PollInterval)
 
-	Configure(Options{
+	err = Configure(Options{
 		ServerAddr:   "localhost:6379",
 		ProcessID:    "1",
 		PollInterval: 1,
 	})
 
+	assert.NoError(t, err)
 	assert.Equal(t, 1, Config.PollInterval)
 }
 
-func TestSentinelConfig(t *testing.T) {
-	Configure(Options{
+func TestSentinelConfigGood(t *testing.T) {
+	err := Configure(Options{
+		SentinelAddrs:   "localhost:26379,localhost:46379",
+		RedisMasterName: "123",
+		ProcessID:       "1",
+		PollInterval:    1,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "FailoverClient", Config.Client.Options().Addr)
+}
+
+func TestSentinelConfigNoMaster(t *testing.T) {
+	err := Configure(Options{
 		SentinelAddrs: "localhost:26379,localhost:46379",
 		ProcessID:     "1",
 		PollInterval:  1,
 	})
 
-	assert.Equal(t, "FailoverClient", Config.Client.Options().Addr)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Require Redis master name configuration when Sentinel addresses are provided.
