### PR TITLE
Remove commented out function names

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -9,10 +9,6 @@ func BeforeStart(f func()) {
 	beforeStart = append(beforeStart, f)
 }
 
-// func AfterStart
-// func BeforeQuit
-// func AfterQuit
-
 func DuringDrain(f func()) {
 	access.Lock()
 	defer access.Unlock()


### PR DESCRIPTION
These functions were added as comments back in 2016 and seem unnecessary. This PR removes them.