### PR TITLE
Print all Redis errors except empty queue errors

### DIFF
--- a/fetcher.go
+++ b/fetcher.go
@@ -84,11 +84,13 @@ func (f *simpleFetcher) tryFetchMessage() {
 	message, err := f.client.BRPopLPush(f.queue, f.inprogressQueue(), 1*time.Second).Result()
 
 	if err != nil {
-		// If redis returns null, the queue is empty. Just ignore the error.
-		if err == redis.Nil {
+		// If redis returns null, the queue is empty.
+		// Just ignore empty queue errors; print all other errors.
+		if err != redis.Nil {
 			Logger.Println("ERR: ", f.queue, err)
-			time.Sleep(1 * time.Second)
 		}
+
+		time.Sleep(1 * time.Second)
 	} else {
 		f.sendMessage(message)
 	}


### PR DESCRIPTION
Print all Redis errors except empty queue errors, and regardless of error type wait one second before retrying. (resolves #21)