### PR TITLE
Create managers and producers with pre-configured Redis client

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -34,6 +34,17 @@ func NewManager(options Options) (*Manager, error) {
 	}, nil
 }
 
+func NewManagerWithRedisClient(options Options, client *redis.Client) (*Manager, error) {
+	options, err := processOptionsWithRedisClient(options, client)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{
+		uuid: uuid.New(),
+		opts: options,
+	}, nil
+}
+
 func (m *Manager) GetRedisClient() *redis.Client {
 	return m.opts.client
 }

--- a/producer.go
+++ b/producer.go
@@ -43,6 +43,16 @@ func NewProducer(options Options) (*Producer, error) {
 	}, nil
 }
 
+func NewProducerWithRedisClient(options Options, client *redis.Client) (*Producer, error) {
+	options, err := processOptionsWithRedisClient(options, client)
+	if err != nil {
+		return nil, err
+	}
+	return &Producer{
+		opts: options,
+	}, nil
+}
+
 func (p *Producer) GetRedisClient() *redis.Client {
 	return p.opts.client
 }


### PR DESCRIPTION
Allow creating managers and producers with pre-configured Redis client. This makes it possible for users to operate with a complex Redis configuration, beyond what is exposed via current library options.