### PR TITLE
Update go mod support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+env:
+  - GO111MODULE=on
+
 go:
   - 1.11
 


### PR DESCRIPTION
Fixes #30 

Go 1.11 and 1.12 specifically have to have Go Modules turned 'on' when working under go path. 
As such, I've overridden the `GO111MODULE` envvar via the Travis config.