### PR TITLE
api: send empty response if no info is available for stats or retries

### DIFF
--- a/retries.go
+++ b/retries.go
@@ -13,7 +13,7 @@ func (s *apiServer) Retries(w http.ResponseWriter, req *http.Request) {
 		Logger.Println("couldn't retrieve retries filtering query:", err)
 	}
 
-	var allRetries []Retries
+	allRetries := []Retries{}
 	for _, m := range s.managers {
 		r, err := m.GetRetries(page, pageSizeVal, query)
 		if err != nil {

--- a/retries_test.go
+++ b/retries_test.go
@@ -1,0 +1,18 @@
+package workers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetries_Empty(t *testing.T) {
+	a := apiServer{}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/retries", nil)
+	a.Retries(recorder, request)
+
+	assert.Equal(t, "[]\n", recorder.Body.String())
+}

--- a/stats.go
+++ b/stats.go
@@ -31,7 +31,7 @@ func (s *apiServer) Stats(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	var allStats []Stats
+	allStats := []Stats{}
 	for _, m := range s.managers {
 		s, err := m.GetStats()
 		if err != nil {

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,18 @@
+package workers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStats_Empty(t *testing.T) {
+	a := apiServer{}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/stats", nil)
+	a.Stats(recorder, request)
+
+	assert.Equal(t, "[]\n", recorder.Body.String())
+}


### PR DESCRIPTION
Send empty response if no info is available for stats or retries.