### PR TITLE
Use type time.Duration for PollInterval instead of int

### DIFF
--- a/manager_test.go
+++ b/manager_test.go
@@ -74,7 +74,7 @@ func TestNewManagerWithRedisClientNoProcessID(t *testing.T) {
 func TestManager_AddBeforeStartHooks(t *testing.T) {
 	namespace := "prod"
 	opts := testOptionsWithNamespace(namespace)
-	opts.PollInterval = 1
+	opts.PollInterval = time.Second
 	mgr, err := newTestManager(opts)
 	assert.NoError(t, err)
 	var beforeStartCalled int
@@ -101,7 +101,7 @@ func TestManager_AddBeforeStartHooks(t *testing.T) {
 func TestManager_AddDuringDrainHooks(t *testing.T) {
 	namespace := "prod"
 	opts := testOptionsWithNamespace(namespace)
-	opts.PollInterval = 1
+	opts.PollInterval = time.Second
 	mgr, err := newTestManager(opts)
 	assert.NoError(t, err)
 	var duringDrainCalled int
@@ -128,7 +128,7 @@ func TestManager_AddDuringDrainHooks(t *testing.T) {
 func TestManager_AddWorker(t *testing.T) {
 	namespace := "prod"
 	opts := testOptionsWithNamespace(namespace)
-	opts.PollInterval = 1
+	opts.PollInterval = time.Second
 	mgr, err := NewManager(opts)
 	assert.NoError(t, err)
 
@@ -186,7 +186,7 @@ func TestManager_AddWorker(t *testing.T) {
 func TestManager_Run(t *testing.T) {
 	namespace := "mgrruntest"
 	opts := testOptionsWithNamespace(namespace)
-	opts.PollInterval = 1
+	opts.PollInterval = time.Second
 	mgr, err := newTestManager(opts)
 	assert.NoError(t, err)
 	prod := mgr.Producer()
@@ -252,7 +252,7 @@ func TestManager_Run(t *testing.T) {
 func TestManager_inProgressMessages(t *testing.T) {
 	namespace := "mgrruntest"
 	opts := testOptionsWithNamespace(namespace)
-	opts.PollInterval = 1
+	opts.PollInterval = time.Second
 	mgr, err := newTestManager(opts)
 	assert.NoError(t, err)
 	prod, err := NewProducer(opts)

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ import (
 type Options struct {
 	ProcessID    string
 	Namespace    string
-	PollInterval int
+	PollInterval time.Duration
 	Database     int
 	Password     string
 	PoolSize     int
@@ -105,7 +105,7 @@ func validateGeneralOptions(options Options) (Options, error) {
 	}
 
 	if options.PollInterval <= 0 {
-		options.PollInterval = 15
+		options.PollInterval = 15 * time.Second
 	}
 
 	return options, nil

--- a/options_test.go
+++ b/options_test.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"crypto/tls"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -105,16 +106,16 @@ func TestDefaultPollIntervalConfig(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, 15, opts.PollInterval)
+	assert.Equal(t, 15*time.Second, opts.PollInterval)
 
 	opts, err = processOptions(Options{
 		ServerAddr:   "localhost:6379",
 		ProcessID:    "1",
-		PollInterval: 1,
+		PollInterval: time.Second,
 	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, 1, opts.PollInterval)
+	assert.Equal(t, time.Second, opts.PollInterval)
 }
 
 func TestSentinelConfigGood(t *testing.T) {
@@ -122,7 +123,7 @@ func TestSentinelConfigGood(t *testing.T) {
 		SentinelAddrs:   "localhost:26379,localhost:46379",
 		RedisMasterName: "123",
 		ProcessID:       "1",
-		PollInterval:    1,
+		PollInterval:    time.Second,
 	})
 
 	assert.NoError(t, err)
@@ -135,7 +136,7 @@ func TestSentinelConfigGoodTLS(t *testing.T) {
 		SentinelAddrs:   "localhost:26379,localhost:46379",
 		RedisMasterName: "123",
 		ProcessID:       "1",
-		PollInterval:    1,
+		PollInterval:    time.Second,
 		RedisTLSConfig:  &tls.Config{ServerName: "test_tls"},
 	})
 
@@ -149,7 +150,7 @@ func TestSentinelConfigNoMaster(t *testing.T) {
 	_, err := processOptions(Options{
 		SentinelAddrs: "localhost:26379,localhost:46379",
 		ProcessID:     "1",
-		PollInterval:  1,
+		PollInterval:  time.Second,
 	})
 
 	assert.Error(t, err)

--- a/scheduled.go
+++ b/scheduled.go
@@ -20,7 +20,7 @@ func (s *scheduledWorker) run() {
 
 		s.poll()
 
-		time.Sleep(time.Duration(s.opts.PollInterval) * time.Second)
+		time.Sleep(s.opts.PollInterval)
 	}
 }
 


### PR DESCRIPTION
The type `time.Duration` from the standard library makes the option `PollInterval` more flexible. I have a project with an end-to-end test that creates and then shuts down the `manager`, which takes at least 1 second with the `int` type being used in seconds. Using `time.Duration`, I can make my tests run 10x faster with `PollInterval = 100ms`.