### PR TITLE
Fixing segfault caused by nil value in redisStore.logger

### DIFF
--- a/storage/redis.go
+++ b/storage/redis.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"time"
 
@@ -24,6 +25,7 @@ func NewRedisStore(namespace string, client *redis.Client) Store {
 	return &redisStore{
 		namespace: namespace,
 		client:    client,
+		logger:    log.New(os.Stdout, "workers: ", log.Ldate|log.Lmicroseconds),
 	}
 }
 


### PR DESCRIPTION
Line https://github.com/digitalocean/go-workers2/blob/master/storage/redis.go#L37 will segfault if `r.client.BRPopLPush` returns an error because `logger` is nil 