### PR TITLE
Move panic recovery to its own middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -30,6 +30,7 @@ var defaultMiddlewares = NewMiddlewares(
 	LogMiddleware,
 	RetryMiddleware,
 	StatsMiddleware,
+	RecoverMiddleware,
 )
 
 func DefaultMiddlewares() Middlewares {

--- a/middleware_recover.go
+++ b/middleware_recover.go
@@ -1,0 +1,21 @@
+package workers
+
+import (
+	"fmt"
+)
+
+// RecoverMiddleware is the default panic/recover middleware.
+func RecoverMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
+	return func(message *Msg) (err error) {
+		defer func() {
+			if e := recover(); e != nil {
+				var ok bool
+				if err, ok = e.(error); !ok {
+					err = fmt.Errorf("%v", e)
+				}
+			}
+		}()
+
+		return next(message)
+	}
+}

--- a/middleware_recover_test.go
+++ b/middleware_recover_test.go
@@ -1,0 +1,23 @@
+package workers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecover(t *testing.T) {
+	wares := NewMiddlewares(RecoverMiddleware)
+	message, _ := NewMsg("{\"jid\":\"2\"}")
+
+	t.Run("recovers", func(t *testing.T) {
+		opts, err := setupTestOptionsWithNamespace("prod")
+		assert.NoError(t, err)
+
+		mgr := &Manager{opts: opts}
+
+		// Test panic
+		err = wares.build("myqueue", mgr, panickingFunc)(message)
+		assert.Error(t, err)
+	})
+}

--- a/task_runner.go
+++ b/task_runner.go
@@ -1,7 +1,6 @@
 package workers
 
 import (
-	"fmt"
 	"sync"
 	"time"
 )
@@ -45,15 +44,6 @@ func (w *taskRunner) work(messages <-chan *Msg, done chan<- *Msg, ready chan<- b
 }
 
 func (w *taskRunner) process(message *Msg) (err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			var ok bool
-			if err, ok = e.(error); !ok {
-				err = fmt.Errorf("%v", e)
-			}
-		}
-	}()
-
 	return w.handler(message)
 }
 

--- a/task_runner_test.go
+++ b/task_runner_test.go
@@ -11,15 +11,6 @@ import (
 func TestTaskRunner_process(t *testing.T) {
 	msg, _ := NewMsg(`{}`)
 
-	t.Run("handles-panic", func(t *testing.T) {
-		tr := newTaskRunner(func(m *Msg) error {
-			panic("task-test-panic")
-		})
-		err := tr.process(msg)
-		assert.EqualError(t, err, "task-test-panic")
-
-	})
-
 	t.Run("returns-error", func(t *testing.T) {
 		var errorToRet error
 		tr := newTaskRunner(func(m *Msg) error {


### PR DESCRIPTION
This allows panic handling to be overridden by other middleware.

This would be a potentially breaking change to clients _not_ using the default middleware I think.