### PR TITLE
Refactor API server init, updated variable names to match golang casing

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -84,14 +84,14 @@ func (m *Manager) AddDuringDrainHooks(hooks ...func()) {
 	m.duringDrainHooks = append(m.duringDrainHooks, hooks...)
 }
 
-// SetRetriesExhaustedHandler sets function(s) that will be sequentially executed when retries are exhausted for a job.
+// SetRetriesExhaustedHandlers sets function(s) that will be sequentially executed when retries are exhausted for a job.
 func (m *Manager) SetRetriesExhaustedHandlers(handlers ...RetriesExhaustedFunc) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.retriesExhaustedHandlers = handlers
 }
 
-// AddRetriesExhaustedHandler adds function(s) to be executed when retries are exhausted for a job.
+// AddRetriesExhaustedHandlers adds function(s) to be executed when retries are exhausted for a job.
 func (m *Manager) AddRetriesExhaustedHandlers(handlers ...RetriesExhaustedFunc) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -111,7 +111,7 @@ func (m *Manager) Run() {
 		h()
 	}
 
-	globalApiServer.registerManager(m)
+	globalAPIServer.registerManager(m)
 
 	var wg sync.WaitGroup
 
@@ -143,7 +143,7 @@ func (m *Manager) Run() {
 	wg.Wait()
 	// Regain the lock
 	m.lock.Lock()
-	globalApiServer.deregisterManager(m)
+	globalAPIServer.deregisterManager(m)
 	m.running = false
 }
 
@@ -221,14 +221,14 @@ func (m *Manager) GetStats() (Stats, error) {
 }
 
 // GetRetries returns the set of retry jobs for the manager
-func (m *Manager) GetRetries(page uint64, page_size int64, match string) (Retries, error) {
+func (m *Manager) GetRetries(page uint64, pageSize int64, match string) (Retries, error) {
 	retries := Retries{}
 
 	storeRetries, err := m.opts.store.GetAllRetries()
 	if err != nil {
 		return retries, err
 	}
-	retryStats := m.opts.client.ZScan(m.opts.Namespace+storage.RetryKey, page, match, page_size).Iterator()
+	retryStats := m.opts.client.ZScan(m.opts.Namespace+storage.RetryKey, page, match, pageSize).Iterator()
 
 	var messages []*Msg
 
@@ -249,15 +249,15 @@ func (m *Manager) GetRetries(page uint64, page_size int64, match string) (Retrie
 		if err != nil {
 			return retries, err
 		}
-		error_msg, err := messages[i].Get("error_message").String()
+		errorMsg, err := messages[i].Get("error_message").String()
 		if err != nil {
 			return retries, err
 		}
-		failed_at, err := messages[i].Get("failed_at").String()
+		failedAt, err := messages[i].Get("failed_at").String()
 		if err != nil {
 			return retries, err
 		}
-		job_id, err := messages[i].Get("jid").String()
+		jobID, err := messages[i].Get("jid").String()
 		if err != nil {
 			return retries, err
 		}
@@ -265,18 +265,18 @@ func (m *Manager) GetRetries(page uint64, page_size int64, match string) (Retrie
 		if err != nil {
 			return retries, err
 		}
-		retry_count, err := messages[i].Get("retry_count").Int64()
+		retryCount, err := messages[i].Get("retry_count").Int64()
 		if err != nil {
 			return retries, err
 		}
 
 		retryJobStats = append(retryJobStats, RetryJobStats{
 			Class:        class,
-			ErrorMessage: error_msg,
-			FailedAt:     failed_at,
-			JobID:        job_id,
+			ErrorMessage: errorMsg,
+			FailedAt:     failedAt,
+			JobID:        jobID,
 			Queue:        queue,
-			RetryCount:   retry_count,
+			RetryCount:   retryCount,
 		})
 	}
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -211,7 +211,7 @@ func TestManager_Run(t *testing.T) {
 	q1cc.ackSyncCh <- true
 
 	// Test that the manager is registered in the stats server
-	assert.Contains(t, globalApiServer.managers, mgr.uuid)
+	assert.Contains(t, globalAPIServer.managers, mgr.uuid)
 
 	// Test that it runs a scheduledWorker
 	_, err = prod.EnqueueIn("queue1", "any", 2, q1cc.syncMsg().Args().Interface())
@@ -224,7 +224,7 @@ func TestManager_Run(t *testing.T) {
 	wg.Wait()
 
 	// Test that the manager is deregistered from the stats server
-	assert.NotContains(t, globalApiServer.managers, mgr.uuid)
+	assert.NotContains(t, globalAPIServer.managers, mgr.uuid)
 
 	// Test that we can restart the manager
 	go func() {
@@ -242,7 +242,7 @@ func TestManager_Run(t *testing.T) {
 	q1cc.ackSyncCh <- true
 
 	// Test that we're back in the global stats server
-	assert.Contains(t, globalApiServer.managers, mgr.uuid)
+	assert.Contains(t, globalAPIServer.managers, mgr.uuid)
 
 	mgr.Stop()
 	wg.Wait()

--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// A function that gets executed when retry attempts have been exhausted.
+// RetriesExhaustedFunc gets executed when retry attempts have been exhausted.
 type RetriesExhaustedFunc func(queue string, message *Msg, err error)
 
 const (

--- a/retries.go
+++ b/retries.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *apiServer) Retries(w http.ResponseWriter, req *http.Request) {
-	page, pageSizeVal, query, err := parseUrlQuery(req)
+	page, pageSizeVal, query, err := parseURLQuery(req)
 	if err != nil {
 		Logger.Println("couldn't retrieve retries filtering query:", err)
 	}
@@ -31,11 +31,13 @@ func (s *apiServer) Retries(w http.ResponseWriter, req *http.Request) {
 	enc.Encode(allRetries)
 }
 
+// Retries stores retry information
 type Retries struct {
 	TotalRetryCount int64           `json:"total_retry_count"`
 	RetryJobs       []RetryJobStats `json:"retry_jobs"`
 }
 
+// RetryJobStats stores information about a single retry job
 type RetryJobStats struct {
 	Class        string `json:"class"`
 	ErrorMessage string `json:"error_message"`
@@ -45,7 +47,7 @@ type RetryJobStats struct {
 	RetryCount   int64  `json:"retry_count"`
 }
 
-func parseUrlQuery(req *http.Request) (uint64, int64, string, error) {
+func parseURLQuery(req *http.Request) (uint64, int64, string, error) {
 	query := req.URL.Query().Get("q")
 	if len(query) > 0 {
 		query = fmt.Sprintf("*" + query + "*")

--- a/server.go
+++ b/server.go
@@ -8,11 +8,16 @@ import (
 
 var globalHTTPServer *http.Server
 
+var globalAPIServer = &apiServer{
+	managers: map[string]*Manager{},
+}
+
+// StartAPIServer starts the API server
 func StartAPIServer(port int) {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/stats", globalApiServer.Stats)
-	mux.HandleFunc("/retries", globalApiServer.Retries)
+	mux.HandleFunc("/stats", globalAPIServer.Stats)
+	mux.HandleFunc("/retries", globalAPIServer.Retries)
 
 	Logger.Println("APIs are available at", fmt.Sprintf("http://localhost:%v/", port))
 
@@ -22,6 +27,7 @@ func StartAPIServer(port int) {
 	}
 }
 
+// StopAPIServer stops the API server
 func StopAPIServer() {
 	if globalHTTPServer != nil {
 		globalHTTPServer.Shutdown(context.Background())

--- a/stats.go
+++ b/stats.go
@@ -11,10 +11,6 @@ type apiServer struct {
 	managers map[string]*Manager
 }
 
-var globalApiServer = &apiServer{
-	managers: map[string]*Manager{},
-}
-
 func (s *apiServer) registerManager(m *Manager) {
 	s.lock.Lock()
 	defer s.lock.Unlock()


### PR DESCRIPTION
Refactor API server init, updated variable names to match golang casing and also add missing func documentation.
