### PR TITLE
allow users to use their own API server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/
+/.idea/

--- a/api_server.go
+++ b/api_server.go
@@ -30,17 +30,16 @@ var globalAPIServer = &apiServer{
 	managers: map[string]*Manager{},
 }
 
-// GlobalAPIHandler exports the API handler
-func GlobalAPIHandler() http.Handler {
-	mux := http.NewServeMux()
+// RegisterAPIEndpoints sets up API server endpoints
+func RegisterAPIEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/stats", globalAPIServer.Stats)
 	mux.HandleFunc("/retries", globalAPIServer.Retries)
-	return mux
 }
 
 // StartAPIServer starts the API server
 func StartAPIServer(port int) {
-	mux := GlobalAPIHandler()
+	mux := http.NewServeMux()
+	RegisterAPIEndpoints(mux)
 
 	Logger.Println("APIs are available at", fmt.Sprintf("http://localhost:%v/", port))
 

--- a/api_server.go
+++ b/api_server.go
@@ -30,12 +30,17 @@ var globalAPIServer = &apiServer{
 	managers: map[string]*Manager{},
 }
 
-// StartAPIServer starts the API server
-func StartAPIServer(port int) {
+// GlobalAPIHandler exports the API handler
+func GlobalAPIHandler() http.Handler {
 	mux := http.NewServeMux()
-
 	mux.HandleFunc("/stats", globalAPIServer.Stats)
 	mux.HandleFunc("/retries", globalAPIServer.Retries)
+	return mux
+}
+
+// StartAPIServer starts the API server
+func StartAPIServer(port int) {
+	mux := GlobalAPIHandler()
 
 	Logger.Println("APIs are available at", fmt.Sprintf("http://localhost:%v/", port))
 


### PR DESCRIPTION
If you are already running your own http listener for stats/metrics it makes little sense to run another one just for go-workers2 stats and retries.

This PR exposes the http.Handler that is used by go-workers2 stats API so that it can be mixed into a custom mux handler.

For an example of how this handler can be used see https://github.com/tomcz/example-miniredis/blob/e20948a0c794524968a8de4435591e6a43098c85/cmd/example/main.go#L120.