### PR TITLE
ensure manager logger uses logger from options

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -35,8 +35,9 @@ func NewManager(options Options) (*Manager, error) {
 	}
 
 	return &Manager{
-		uuid: uuid.New().String(),
-		opts: options,
+		uuid:   uuid.New().String(),
+		logger: options.Logger,
+		opts:   options,
 	}, nil
 }
 
@@ -48,8 +49,9 @@ func NewManagerWithRedisClient(options Options, client *redis.Client) (*Manager,
 	}
 
 	return &Manager{
-		uuid: uuid.New().String(),
-		opts: options,
+		uuid:   uuid.New().String(),
+		logger: options.Logger,
+		opts:   options,
 	}, nil
 }
 
@@ -69,7 +71,7 @@ func (m *Manager) AddWorker(queue string, concurrency int, job JobFunc, mids ...
 	} else {
 		job = NewMiddlewares(mids...).build(middlewareQueueName, m, job)
 	}
-	m.workers = append(m.workers, newWorker(queue, concurrency, job))
+	m.workers = append(m.workers, newWorker(m.logger, queue, concurrency, job))
 }
 
 // AddBeforeStartHooks adds functions to be executed before the manager starts

--- a/task_runner_test.go
+++ b/task_runner_test.go
@@ -12,7 +12,7 @@ func TestTaskRunner_process(t *testing.T) {
 	msg, _ := NewMsg(`{}`)
 
 	t.Run("handles-panic", func(t *testing.T) {
-		tr := newTaskRunner(func(m *Msg) error {
+		tr := newTaskRunner(Logger, func(m *Msg) error {
 			panic("task-test-panic")
 		})
 		err := tr.process(msg)
@@ -22,7 +22,7 @@ func TestTaskRunner_process(t *testing.T) {
 
 	t.Run("returns-error", func(t *testing.T) {
 		var errorToRet error
-		tr := newTaskRunner(func(m *Msg) error {
+		tr := newTaskRunner(Logger, func(m *Msg) error {
 			return errorToRet
 		})
 		err := tr.process(msg)
@@ -49,7 +49,7 @@ func TestTaskRunner(t *testing.T) {
 		return m
 	}
 
-	tr := newTaskRunner(func(m *Msg) error {
+	tr := newTaskRunner(Logger, func(m *Msg) error {
 		if m.Get("sync").MustBool() {
 			syncCh <- true
 			<-syncCh

--- a/worker_test.go
+++ b/worker_test.go
@@ -27,7 +27,7 @@ func (d dummyFetcher) Closed() bool        { return d.closed() }
 
 func TestNewWorker(t *testing.T) {
 	cc := newCallCounter()
-	w := newWorker("q", 0, cc.F)
+	w := newWorker(Logger, "q", 0, cc.F)
 	assert.Equal(t, "q", w.queue)
 	assert.Equal(t, 1, w.concurrency)
 	assert.NotNil(t, w.stop)
@@ -36,10 +36,10 @@ func TestNewWorker(t *testing.T) {
 	w.handler(nil)
 	assert.Equal(t, 1, cc.count)
 
-	w = newWorker("q", -5, cc.F)
+	w = newWorker(Logger, "q", -5, cc.F)
 	assert.Equal(t, 1, w.concurrency)
 
-	w = newWorker("q", 10, cc.F)
+	w = newWorker(Logger, "q", 10, cc.F)
 	assert.Equal(t, 10, w.concurrency)
 }
 
@@ -71,7 +71,7 @@ func TestWorker(t *testing.T) {
 
 	cc := newCallCounter()
 
-	w := newWorker("q", 2, cc.F)
+	w := newWorker(Logger, "q", 2, cc.F)
 
 	var wg sync.WaitGroup
 	go func() {
@@ -160,7 +160,7 @@ func TestWorkerProcessesAndAcksMessages(t *testing.T) {
 	}
 
 	cc := newCallCounter()
-	w := newWorker("q", 1, cc.F)
+	w := newWorker(Logger, "q", 1, cc.F)
 
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
Ensure manager logger is not nil which can lead to panics in the logging middleware, and log any errors and panics in the task runner so we don't have any silent failures.