### PR TITLE
[WIP] Active/passive failover support by worker manager clusters

### DIFF
--- a/all_specs_test.go
+++ b/all_specs_test.go
@@ -16,11 +16,12 @@ func setupTestOptionsWithNamespace(namespace string) (Options, error) {
 
 func testOptionsWithNamespace(namespace string) Options {
 	return Options{
-		ServerAddr: "localhost:6379",
-		ProcessID:  "1",
-		Database:   15,
-		PoolSize:   1,
-		Namespace:  namespace,
+		ServerAddr:       "localhost:6379",
+		ProcessID:        "1",
+		Database:         15,
+		PoolSize:         1,
+		Namespace:        namespace,
+		FailoverStrategy: NoFailover,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -12,6 +12,14 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
+type FailoverStrategy int
+
+const (
+	NoFailover FailoverStrategy = iota
+	ActivePassiveFailover
+	ActiveActiveFailover
+)
+
 // Options contains the set of configuration options for a manager and/or producer
 type Options struct {
 	ProcessID    string
@@ -29,6 +37,13 @@ type Options struct {
 
 	// Optional display name used when displaying manager stats
 	ManagerDisplayName string
+
+	FailoverStrategy FailoverStrategy
+
+	// One or more managers can belong to a cluster
+	// Active/passive failover will failover by cluster
+	ClusterName     string
+	ClusterPriority float64
 
 	// Log
 	Logger *log.Logger

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -37,6 +37,10 @@ type Retries struct {
 
 // Store is the interface for storing and retrieving data
 type Store interface {
+	// Worker manager cluster operations
+	AddActiveCluster(ctx context.Context, managerUUID string, managerPriority float64) error
+	EvictExpiredClusters(ctx context.Context, expireTS int64) error
+	GetActiveClusterName(ctx context.Context) (string, error)
 
 	// General queue operations
 	CreateQueue(ctx context.Context, queue string) error
@@ -59,4 +63,7 @@ type Store interface {
 
 	// Retries
 	GetAllRetries(ctx context.Context) (*Retries, error)
+
+	// Misc
+	GetTime(ctx context.Context) (time.Time, error)
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -12,6 +12,7 @@ import (
 type dummyFetcher struct {
 	queue       func() string
 	fetch       func()
+	setActive   func(bool)
 	acknowledge func(*Msg)
 	ready       func() chan bool
 	messages    func() chan *Msg
@@ -19,13 +20,14 @@ type dummyFetcher struct {
 	closed      func() bool
 }
 
-func (d dummyFetcher) Queue() string       { return d.queue() }
-func (d dummyFetcher) Fetch()              { d.fetch() }
-func (d dummyFetcher) Acknowledge(m *Msg)  { d.acknowledge(m) }
-func (d dummyFetcher) Ready() chan bool    { return d.ready() }
-func (d dummyFetcher) Messages() chan *Msg { return d.messages() }
-func (d dummyFetcher) Close()              { d.close() }
-func (d dummyFetcher) Closed() bool        { return d.closed() }
+func (d dummyFetcher) Queue() string         { return d.queue() }
+func (d dummyFetcher) Fetch()                { d.fetch() }
+func (d dummyFetcher) Acknowledge(m *Msg)    { d.acknowledge(m) }
+func (d dummyFetcher) Ready() chan bool      { return d.ready() }
+func (d dummyFetcher) SetActive(active bool) { d.setActive(active) }
+func (d dummyFetcher) Messages() chan *Msg   { return d.messages() }
+func (d dummyFetcher) Close()                { d.close() }
+func (d dummyFetcher) Closed() bool          { return d.closed() }
 
 func TestNewWorker(t *testing.T) {
 	testLogger := log.New(os.Stdout, "test-go-workers2: ", log.Ldate|log.Lmicroseconds)


### PR DESCRIPTION
**[WIP] Active/passive failover support by worker manager clusters**

_Summary_
This PR adds explicit failover strategy, with an initial support for active/passive failover based on clusters of managers that are assigned a priority by cluster. The highest priority cluster is then determined to be the currently active cluster of managers. Given active/passive failover is configured, a heart beat is initialized in each manager. This heart beat registers a given manager's cluster as active, evicts outdated active cluster, and if a given manager belongs to the highest priority active cluster, it will process queued work.

