### PR TITLE
Enable support for enqueueing with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ func main() {
   // Add a job to a queue with retry
   producer.EnqueueWithOptions("myqueue3", "Add", []int{1, 2}, workers.EnqueueOptions{Retry: true})
 
+  // Add a job to a queue passing the context to redis
+  producer.EnqueueWithContext(ctx.Background(), "myqueue3", "Add", []int{1, 2}, workers.EnqueueOptions{Retry: true})
+
   // stats will be available at http://localhost:8080/stats
   go workers.StartAPIServer(8080)
 

--- a/producer.go
+++ b/producer.go
@@ -86,6 +86,11 @@ func (p *Producer) EnqueueAt(queue, class string, at time.Time, args interface{}
 
 // EnqueueWithOptions enqueues new work for processing with the given options
 func (p *Producer) EnqueueWithOptions(queue, class string, args interface{}, opts EnqueueOptions) (string, error) {
+	return p.EnqueueWithContext(context.Background(), queue, class, args, opts)
+}
+
+// EnqueueWithContext enqueues new work for processing with the given options and context
+func (p *Producer) EnqueueWithContext(ctx context.Context, queue, class string, args interface{}, opts EnqueueOptions) (string, error) {
 	now := nowToSecondsWithNanoPrecision()
 	data := EnqueueData{
 		Queue:          queue,
@@ -102,16 +107,16 @@ func (p *Producer) EnqueueWithOptions(queue, class string, args interface{}, opt
 	}
 
 	if now < opts.At {
-		err = p.opts.store.EnqueueScheduledMessage(context.Background(), data.At, string(bytes))
+		err = p.opts.store.EnqueueScheduledMessage(ctx, data.At, string(bytes))
 		return data.Jid, err
 	}
 
-	err = p.opts.store.CreateQueue(context.Background(), queue)
+	err = p.opts.store.CreateQueue(ctx, queue)
 	if err != nil {
 		return "", err
 	}
 
-	err = p.opts.store.EnqueueMessageNow(context.Background(), queue, string(bytes))
+	err = p.opts.store.EnqueueMessageNow(ctx, queue, string(bytes))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Create an `EnqueueWithContext` method on producer so we can enqueue jobs with a custom context.

Reason: This will allow usage of Redis Tracer for Datadog when configuring the producer, and let it associate the span to other spans created in the same context.