### PR TITLE
Fix issues with enqueued stat always being empty

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -242,7 +242,7 @@ func (m *Manager) GetStats() (Stats, error) {
 	stats.Failed = storeStats.Failed
 	stats.RetryCount = storeStats.RetryCount
 
-	for q, l := range stats.Enqueued {
+	for q, l := range storeStats.Enqueued {
 		stats.Enqueued[q] = l
 	}
 


### PR DESCRIPTION
The enqueued stat is always empty in the /stats endpoint because of a bug in the managers call to `GetStatus`

Fixes that bug by ranging over the returned stats from the store interface