### PR TITLE
Fix Heartbeat compatibility, Add HeartBeatLastPushedAt to Manager Stats

### DIFF
--- a/api_stats.go
+++ b/api_stats.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 )
 
 func (s *apiServer) Stats(w http.ResponseWriter, req *http.Request) {
@@ -24,14 +25,15 @@ func (s *apiServer) Stats(w http.ResponseWriter, req *http.Request) {
 	enc.Encode(allStats)
 }
 
-// Stats containts current stats for a manager
+// Stats contains current stats for a manager
 type Stats struct {
-	Name       string                 `json:"manager_name"`
-	Processed  int64                  `json:"processed"`
-	Failed     int64                  `json:"failed"`
-	Jobs       map[string][]JobStatus `json:"jobs"`
-	Enqueued   map[string]int64       `json:"enqueued"`
-	RetryCount int64                  `json:"retry_count"`
+	Name                  string                 `json:"manager_name"`
+	Processed             int64                  `json:"processed"`
+	Failed                int64                  `json:"failed"`
+	Jobs                  map[string][]JobStatus `json:"jobs"`
+	Enqueued              map[string]int64       `json:"enqueued"`
+	RetryCount            int64                  `json:"retry_count"`
+	HeartbeatLastPushedAt time.Time              `json:"heartbeat_last_pushed_at"`
 }
 
 // JobStatus contains the status and data for active jobs of a manager

--- a/manager.go
+++ b/manager.go
@@ -323,24 +323,24 @@ func (m *Manager) startHeartbeat() error {
 				m.logger.Println("ERR: Failed to get heartbeat time", err)
 				return err
 			}
-			heartbeat, err := m.sendHeartbeat(heartbeatTime)
+			_, err = m.sendHeartbeat(heartbeatTime)
 			if err != nil {
-				m.logger.Println("ERR: Failed to send heartbeat", err)
 				return err
 			}
-			expireTS := heartbeatTime.Add(-m.opts.Heartbeat.HeartbeatTTL).Unix()
-			staleMessageUpdates, err := m.handleAllExpiredHeartbeats(context.Background(), expireTS)
-			if err != nil {
-				m.logger.Println("ERR: error expiring heartbeat identities", err)
-				return err
-			}
-			for _, afterHeartbeatHook := range m.afterHeartbeatHooks {
-				err := afterHeartbeatHook(heartbeat, m, staleMessageUpdates)
-				if err != nil {
-					m.logger.Println("ERR: Failed to execute after heartbeat hook", err)
-					return err
-				}
-			}
+
+			//expireTS := heartbeatTime.Add(-m.opts.Heartbeat.HeartbeatTTL).Unix()
+			//staleMessageUpdates, err := m.handleAllExpiredHeartbeats(context.Background(), expireTS)
+			//if err != nil {
+			//	m.logger.Println("ERR: error expiring heartbeat identities", err)
+			//	return err
+			//}
+			//for _, afterHeartbeatHook := range m.afterHeartbeatHooks {
+			//	err := afterHeartbeatHook(heartbeat, m, staleMessageUpdates)
+			//	if err != nil {
+			//		m.logger.Println("ERR: Failed to execute after heartbeat hook", err)
+			//		return err
+			//	}
+			//}
 			m.heartbeatLastPushedAt = time.Now()
 		case <-m.heartbeatChannel:
 			return nil
@@ -426,7 +426,9 @@ func (m *Manager) sendHeartbeat(heartbeatTime time.Time) (*storage.Heartbeat, er
 	}
 
 	err = m.opts.store.SendHeartbeat(context.Background(), heartbeat)
-	m.logger.Println("ERR: Failed to send heartbeat", err)
+	if err != nil {
+		m.logger.Println("ERR: Failed to send heartbeat", err)
+	}
 	return heartbeat, err
 }
 

--- a/manager.go
+++ b/manager.go
@@ -421,10 +421,12 @@ func (m *Manager) stopHeartbeat() {
 func (m *Manager) sendHeartbeat(heartbeatTime time.Time) (*storage.Heartbeat, error) {
 	heartbeat, err := m.buildHeartbeat(heartbeatTime, m.opts.Heartbeat.HeartbeatTTL)
 	if err != nil {
+		m.logger.Println("ERR: Failed to build heartbeat", err)
 		return heartbeat, err
 	}
 
 	err = m.opts.store.SendHeartbeat(context.Background(), heartbeat)
+	m.logger.Println("ERR: Failed to send heartbeat", err)
 	return heartbeat, err
 }
 

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -160,6 +160,22 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"active_manager", heartbeat.ActiveManager,
 		"worker_heartbeats", workerHeartbeats)
 
+	// ensure the heartbeat is automatically cleaned up
+	pipe.Expire(ctx, managerKey, heartbeat.Ttl)
+
+	// delete the worker key just in case
+	pipe.Del(ctx, GetWorkersKey(managerKey))
+
+	// send all job heartbeats
+	for tid, msg := range heartbeat.WorkerHeartbeats {
+		// fake the sidekiq thread id
+		fakeThreadId := fmt.Sprintf("%d-%s", heartbeat.Pid, tid)
+		pipe.HSet(ctx, GetWorkersKey(managerKey), fakeThreadId, msg)
+	}
+
+	// make sure the worker is cleaned up
+	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
+
 	_, err = pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -144,6 +144,11 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	managerKey := GetManagerKey(r.namespace, heartbeat.Identity)
 	pipe.SAdd(ctx, GetProcessesKey(r.namespace), heartbeat.Identity) // add to the sidekiq processes set without the namespace
 
+	workerHeartbeats, err := json.Marshal(heartbeat.WorkerHeartbeats)
+	if err != nil {
+		return err
+	}
+
 	pipe.HMSet(ctx, managerKey,
 		"beat", heartbeat.Beat,
 		"quiet", heartbeat.Quiet,
@@ -152,16 +157,17 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"rss", heartbeat.RSS,
 		"info", heartbeat.Info,
 		"manager_priority", heartbeat.ManagerPriority,
-		"active_manager", heartbeat.ActiveManager)
+		"active_manager", heartbeat.ActiveManager,
+		"worker_heartbeats", workerHeartbeats)
 
 	// ensure the heartbeat is automatically cleaned up
 	pipe.Expire(ctx, managerKey, heartbeat.Ttl)
 
-	// delete the worker key just in case
+	// delete the worker key just in case our set is empty
 	pipe.Del(ctx, GetWorkersKey(managerKey))
 
-	// send all job heartbeats
-	for tid, msg := range heartbeat.WorkerHeartbeats {
+	// send all job message heartbeats
+	for tid, msg := range heartbeat.WorkerMessages {
 		// fake the sidekiq thread id
 		fakeThreadId := fmt.Sprintf("%d-%s", heartbeat.Pid, tid)
 		pipe.HSet(ctx, GetWorkersKey(managerKey), fakeThreadId, msg)
@@ -170,7 +176,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	// make sure the worker is cleaned up
 	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
 
-	_, err := pipe.Exec(ctx)
+	_, err = pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err
 	}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -170,7 +170,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	// make sure the worker is cleaned up
 	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
 
-	_, err = pipe.Exec(ctx)
+	_, err := pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err
 	}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -144,11 +144,6 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	managerKey := GetManagerKey(r.namespace, heartbeat.Identity)
 	pipe.SAdd(ctx, GetProcessesKey(r.namespace), heartbeat.Identity) // add to the sidekiq processes set without the namespace
 
-	workerHeartbeats, err := json.Marshal(heartbeat.WorkerHeartbeats)
-	if err != nil {
-		return err
-	}
-
 	pipe.HMSet(ctx, managerKey,
 		"beat", heartbeat.Beat,
 		"quiet", heartbeat.Quiet,
@@ -157,8 +152,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"rss", heartbeat.RSS,
 		"info", heartbeat.Info,
 		"manager_priority", heartbeat.ManagerPriority,
-		"active_manager", heartbeat.ActiveManager,
-		"worker_heartbeats", workerHeartbeats)
+		"active_manager", heartbeat.ActiveManager)
 
 	// ensure the heartbeat is automatically cleaned up
 	pipe.Expire(ctx, managerKey, heartbeat.Ttl)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -39,15 +39,16 @@ type Retries struct {
 type Heartbeat struct {
 	Identity string `json:"identity"`
 
-	Beat            int64  `json:"beat,string"`
-	Quiet           bool   `json:"quiet,string"`
-	Busy            int    `json:"busy,string"`
-	RttUS           int    `json:"rtt_us,string"`
-	RSS             int64  `json:"rss,string"`
-	Info            string `json:"info"`
-	Pid             int    `json:"pid,string"`
-	ManagerPriority int    `json:"manager_priority,string"`
-	ActiveManager   bool   `json:"active_manager,string"`
+	Beat            int64             `json:"beat,string"`
+	Quiet           bool              `json:"quiet,string"`
+	Busy            int               `json:"busy,string"`
+	RttUS           int               `json:"rtt_us,string"`
+	RSS             int64             `json:"rss,string"`
+	Info            string            `json:"info"`
+	Pid             int               `json:"pid,string"`
+	ManagerPriority int               `json:"manager_priority,string"`
+	ActiveManager   bool              `json:"active_manager,string"`
+	WorkerMessages  map[string]string `json:"worker_messages"`
 
 	Ttl time.Duration
 


### PR DESCRIPTION
This MR does two things.

1. Fixes compatibility with the sidekiq web UI, heartbeats were not autoexpiring, and jobs for an individual worker were not being set to the correct key. 
2. Adds `HeartBeatLastPushedAt` to manager stats so you can build a liveness probe in case the worker process crashes.

Note:
I've commented out some code that reads the heartbeats, from my observations of sidekiq.rb's heartbeat code it is never read, just pushed to. If the recent code that was added that modifies heartbeats to be read is necessary, I would recommend it being moved into a different data structure.