### PR TITLE
Validate heartbeat configuration set by the user

### DIFF
--- a/options.go
+++ b/options.go
@@ -159,5 +159,10 @@ func validateGeneralOptions(options Options) (Options, error) {
 		options.PollInterval = 15 * time.Second
 	}
 
+	if options.Heartbeat != nil &&
+		options.Heartbeat.Interval >= options.Heartbeat.HeartbeatTTL {
+		return Options{}, errors.New("invalid heartbeat configuration, heartbeat interval longer than or equal to heartbeat tll")
+	}
+
 	return options, nil
 }


### PR DESCRIPTION
Validate heartbeat configuration set by the user, the interval should be always shorter than ttl. If this configuration is invalid there is a chance that the heart processor will mark active workers as expired and process them accordingly.

