### PR TITLE
Draft: Add unique enqueue

### DIFF
--- a/api_stats.go
+++ b/api_stats.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 )
 
 func (s *apiServer) Stats(w http.ResponseWriter, req *http.Request) {
@@ -24,14 +25,15 @@ func (s *apiServer) Stats(w http.ResponseWriter, req *http.Request) {
 	enc.Encode(allStats)
 }
 
-// Stats containts current stats for a manager
+// Stats contains current stats for a manager
 type Stats struct {
-	Name       string                 `json:"manager_name"`
-	Processed  int64                  `json:"processed"`
-	Failed     int64                  `json:"failed"`
-	Jobs       map[string][]JobStatus `json:"jobs"`
-	Enqueued   map[string]int64       `json:"enqueued"`
-	RetryCount int64                  `json:"retry_count"`
+	Name                  string                 `json:"manager_name"`
+	Processed             int64                  `json:"processed"`
+	Failed                int64                  `json:"failed"`
+	Jobs                  map[string][]JobStatus `json:"jobs"`
+	Enqueued              map[string]int64       `json:"enqueued"`
+	RetryCount            int64                  `json:"retry_count"`
+	HeartbeatLastPushedAt time.Time              `json:"heartbeat_last_pushed_at"`
 }
 
 // JobStatus contains the status and data for active jobs of a manager

--- a/manager.go
+++ b/manager.go
@@ -323,24 +323,24 @@ func (m *Manager) startHeartbeat() error {
 				m.logger.Println("ERR: Failed to get heartbeat time", err)
 				return err
 			}
-			heartbeat, err := m.sendHeartbeat(heartbeatTime)
+			_, err = m.sendHeartbeat(heartbeatTime)
 			if err != nil {
-				m.logger.Println("ERR: Failed to send heartbeat", err)
 				return err
 			}
-			expireTS := heartbeatTime.Add(-m.opts.Heartbeat.HeartbeatTTL).Unix()
-			staleMessageUpdates, err := m.handleAllExpiredHeartbeats(context.Background(), expireTS)
-			if err != nil {
-				m.logger.Println("ERR: error expiring heartbeat identities", err)
-				return err
-			}
-			for _, afterHeartbeatHook := range m.afterHeartbeatHooks {
-				err := afterHeartbeatHook(heartbeat, m, staleMessageUpdates)
-				if err != nil {
-					m.logger.Println("ERR: Failed to execute after heartbeat hook", err)
-					return err
-				}
-			}
+
+			//expireTS := heartbeatTime.Add(-m.opts.Heartbeat.HeartbeatTTL).Unix()
+			//staleMessageUpdates, err := m.handleAllExpiredHeartbeats(context.Background(), expireTS)
+			//if err != nil {
+			//	m.logger.Println("ERR: error expiring heartbeat identities", err)
+			//	return err
+			//}
+			//for _, afterHeartbeatHook := range m.afterHeartbeatHooks {
+			//	err := afterHeartbeatHook(heartbeat, m, staleMessageUpdates)
+			//	if err != nil {
+			//		m.logger.Println("ERR: Failed to execute after heartbeat hook", err)
+			//		return err
+			//	}
+			//}
 			m.heartbeatLastPushedAt = time.Now()
 		case <-m.heartbeatChannel:
 			return nil
@@ -426,7 +426,9 @@ func (m *Manager) sendHeartbeat(heartbeatTime time.Time) (*storage.Heartbeat, er
 	}
 
 	err = m.opts.store.SendHeartbeat(context.Background(), heartbeat)
-	m.logger.Println("ERR: Failed to send heartbeat", err)
+	if err != nil {
+		m.logger.Println("ERR: Failed to send heartbeat", err)
+	}
 	return heartbeat, err
 }
 

--- a/manager.go
+++ b/manager.go
@@ -421,10 +421,12 @@ func (m *Manager) stopHeartbeat() {
 func (m *Manager) sendHeartbeat(heartbeatTime time.Time) (*storage.Heartbeat, error) {
 	heartbeat, err := m.buildHeartbeat(heartbeatTime, m.opts.Heartbeat.HeartbeatTTL)
 	if err != nil {
+		m.logger.Println("ERR: Failed to build heartbeat", err)
 		return heartbeat, err
 	}
 
 	err = m.opts.store.SendHeartbeat(context.Background(), heartbeat)
+	m.logger.Println("ERR: Failed to send heartbeat", err)
 	return heartbeat, err
 }
 

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package workers
 import (
 	"crypto/tls"
 	"errors"
+	"github.com/digitalocean/go-workers2/unique"
 	"log"
 	"os"
 	"strings"
@@ -39,6 +40,9 @@ type Options struct {
 
 	// Define Heartbeat to enable heartbeat
 	Heartbeat *HeartbeatOptions
+
+	// Unique
+	Unique *unique.Options
 
 	// Log
 	Logger *log.Logger

--- a/producer.go
+++ b/producer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"github.com/digitalocean/go-workers2/unique"
 	"io"
 	"time"
 
@@ -33,10 +34,11 @@ type EnqueueData struct {
 
 // EnqueueOptions stores configuration for new work
 type EnqueueOptions struct {
-	RetryCount int     `json:"retry_count,omitempty"`
-	RetryMax   int     `json:"retry_max,omitempty"`
-	Retry      bool    `json:"retry,omitempty"`
-	At         float64 `json:"at,omitempty"`
+	RetryCount    int            `json:"retry_count,omitempty"`
+	RetryMax      int            `json:"retry_max,omitempty"`
+	Retry         bool           `json:"retry,omitempty"`
+	At            float64        `json:"at,omitempty"`
+	UniqueOptions unique.Options `json:"unique_options,omitempty"`
 }
 
 // NewProducer creates a new producer with the given options
@@ -92,6 +94,7 @@ func (p *Producer) EnqueueWithOptions(queue, class string, args interface{}, opt
 // EnqueueWithContext enqueues new work for processing with the given options and context
 func (p *Producer) EnqueueWithContext(ctx context.Context, queue, class string, args interface{}, opts EnqueueOptions) (string, error) {
 	now := nowToSecondsWithNanoPrecision()
+
 	data := EnqueueData{
 		Queue:          queue,
 		Class:          class,
@@ -116,7 +119,7 @@ func (p *Producer) EnqueueWithContext(ctx context.Context, queue, class string, 
 		return "", err
 	}
 
-	err = p.opts.store.EnqueueMessageNow(ctx, queue, string(bytes))
+	err = p.opts.store.EnqueueMessageNow(ctx, queue, string(bytes), opts.UniqueOptions)
 	if err != nil {
 		return "", err
 	}

--- a/scheduled.go
+++ b/scheduled.go
@@ -2,6 +2,7 @@ package workers
 
 import (
 	"context"
+	"github.com/digitalocean/go-workers2/unique"
 	"strings"
 	"time"
 )
@@ -44,7 +45,7 @@ func (s *scheduledWorker) poll() {
 		queue = strings.TrimPrefix(queue, s.opts.Namespace)
 		message.Set("enqueued_at", nowToSecondsWithNanoPrecision())
 
-		s.opts.store.EnqueueMessageNow(context.Background(), queue, message.ToJson())
+		s.opts.store.EnqueueMessageNow(context.Background(), queue, message.ToJson(), unique.NewOptions())
 	}
 
 	for {
@@ -59,7 +60,7 @@ func (s *scheduledWorker) poll() {
 		queue = strings.TrimPrefix(queue, s.opts.Namespace)
 		message.Set("enqueued_at", nowToSecondsWithNanoPrecision())
 
-		s.opts.store.EnqueueMessageNow(context.Background(), queue, message.ToJson())
+		s.opts.store.EnqueueMessageNow(context.Background(), queue, message.ToJson(), unique.NewOptions())
 	}
 }
 

--- a/signals_posix.go
+++ b/signals_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package workers

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -160,6 +160,22 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"active_manager", heartbeat.ActiveManager,
 		"worker_heartbeats", workerHeartbeats)
 
+	// ensure the heartbeat is automatically cleaned up
+	pipe.Expire(ctx, managerKey, heartbeat.Ttl)
+
+	// delete the worker key just in case
+	pipe.Del(ctx, GetWorkersKey(managerKey))
+
+	// send all job heartbeats
+	for tid, msg := range heartbeat.WorkerHeartbeats {
+		// fake the sidekiq thread id
+		fakeThreadId := fmt.Sprintf("%d-%s", heartbeat.Pid, tid)
+		pipe.HSet(ctx, GetWorkersKey(managerKey), fakeThreadId, msg)
+	}
+
+	// make sure the worker is cleaned up
+	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
+
 	_, err = pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -144,6 +144,11 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	managerKey := GetManagerKey(r.namespace, heartbeat.Identity)
 	pipe.SAdd(ctx, GetProcessesKey(r.namespace), heartbeat.Identity) // add to the sidekiq processes set without the namespace
 
+	workerHeartbeats, err := json.Marshal(heartbeat.WorkerHeartbeats)
+	if err != nil {
+		return err
+	}
+
 	pipe.HMSet(ctx, managerKey,
 		"beat", heartbeat.Beat,
 		"quiet", heartbeat.Quiet,
@@ -152,16 +157,17 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"rss", heartbeat.RSS,
 		"info", heartbeat.Info,
 		"manager_priority", heartbeat.ManagerPriority,
-		"active_manager", heartbeat.ActiveManager)
+		"active_manager", heartbeat.ActiveManager,
+		"worker_heartbeats", workerHeartbeats)
 
 	// ensure the heartbeat is automatically cleaned up
 	pipe.Expire(ctx, managerKey, heartbeat.Ttl)
 
-	// delete the worker key just in case
+	// delete the worker key just in case our set is empty
 	pipe.Del(ctx, GetWorkersKey(managerKey))
 
-	// send all job heartbeats
-	for tid, msg := range heartbeat.WorkerHeartbeats {
+	// send all job message heartbeats
+	for tid, msg := range heartbeat.WorkerMessages {
 		// fake the sidekiq thread id
 		fakeThreadId := fmt.Sprintf("%d-%s", heartbeat.Pid, tid)
 		pipe.HSet(ctx, GetWorkersKey(managerKey), fakeThreadId, msg)
@@ -170,7 +176,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	// make sure the worker is cleaned up
 	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
 
-	_, err := pipe.Exec(ctx)
+	_, err = pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err
 	}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -170,7 +170,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	// make sure the worker is cleaned up
 	pipe.Expire(ctx, GetWorkersKey(managerKey), heartbeat.Ttl)
 
-	_, err = pipe.Exec(ctx)
+	_, err := pipe.Exec(ctx)
 	if err != nil && err != redis.Nil {
 		return err
 	}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -144,11 +144,6 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 	managerKey := GetManagerKey(r.namespace, heartbeat.Identity)
 	pipe.SAdd(ctx, GetProcessesKey(r.namespace), heartbeat.Identity) // add to the sidekiq processes set without the namespace
 
-	workerHeartbeats, err := json.Marshal(heartbeat.WorkerHeartbeats)
-	if err != nil {
-		return err
-	}
-
 	pipe.HMSet(ctx, managerKey,
 		"beat", heartbeat.Beat,
 		"quiet", heartbeat.Quiet,
@@ -157,8 +152,7 @@ func (r *redisStore) SendHeartbeat(ctx context.Context, heartbeat *Heartbeat) er
 		"rss", heartbeat.RSS,
 		"info", heartbeat.Info,
 		"manager_priority", heartbeat.ManagerPriority,
-		"active_manager", heartbeat.ActiveManager,
-		"worker_heartbeats", workerHeartbeats)
+		"active_manager", heartbeat.ActiveManager)
 
 	// ensure the heartbeat is automatically cleaned up
 	pipe.Expire(ctx, managerKey, heartbeat.Ttl)

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -226,16 +226,23 @@ func (r *redisStore) RemoveHeartbeat(ctx context.Context, heartbeatID string) er
 	return nil
 }
 
-func UniqueHash(queue string, message string) string {
-	hasher := sha1.New()
-	hasher.Write([]byte(fmt.Sprintf("%s::%s", queue, message)))
-	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+func uniqueHash(queue string, message string) string {
+	sha1Hasher := sha1.New()
+	sha1Hasher.Write([]byte(fmt.Sprintf("%s::%s", queue, message)))
+	sha := base64.URLEncoding.EncodeToString(sha1Hasher.Sum(nil))
 
 	return fmt.Sprintf("unique::%s", sha)
 }
 
+func (r *redisStore) checkForExistingUniqueMessage(ctx context.Context, queue string, message string) (bool, error) {
+	uniqueKey := uniqueHash(queue, message)
+
+	found, err := r.client.Exists(ctx, uniqueKey).Result()
+	return found == 1, err
+}
+
 func (r *redisStore) setUniqueKey(ctx context.Context, pipe redis.Pipeliner, queue, message string, uniqueFor time.Duration) error {
-	uniqueKey := UniqueHash(queue, message)
+	uniqueKey := uniqueHash(queue, message)
 
 	_, uniqueErr := pipe.SetNX(ctx, uniqueKey, "1", uniqueFor).Result()
 	if uniqueErr != nil {
@@ -351,13 +358,6 @@ func (r *redisStore) DequeueRetriedMessage(ctx context.Context, priority float64
 	}
 
 	return messages[0], nil
-}
-
-func (r *redisStore) checkForExistingUniqueMessage(ctx context.Context, queue string, message string) (bool, error) {
-	uniqueKey := UniqueHash(queue, message)
-
-	found, err := r.client.Exists(ctx, uniqueKey).Result()
-	return found == 1, err
 }
 
 func (r *redisStore) EnqueueMessageNow(ctx context.Context, queue string, message string, options unique.Options) error {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/digitalocean/go-workers2/unique"
 	"log"
 	"strconv"
 	"time"
@@ -223,11 +226,51 @@ func (r *redisStore) RemoveHeartbeat(ctx context.Context, heartbeatID string) er
 	return nil
 }
 
-func (r *redisStore) EnqueueMessage(ctx context.Context, queue string, priority float64, message string) error {
-	_, err := r.client.ZAdd(ctx, r.getQueueName(queue), &redis.Z{
-		Score:  priority,
-		Member: message,
-	}).Result()
+func UniqueHash(queue string, message string) string {
+	hasher := sha1.New()
+	hasher.Write([]byte(fmt.Sprintf("%s::%s", queue, message)))
+	sha := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+
+	return fmt.Sprintf("unique::%s", sha)
+}
+
+func (r *redisStore) setUniqueKey(ctx context.Context, pipe redis.Pipeliner, queue, message string, uniqueFor time.Duration) error {
+	uniqueKey := UniqueHash(queue, message)
+
+	_, uniqueErr := pipe.SetNX(ctx, uniqueKey, "1", uniqueFor).Result()
+	if uniqueErr != nil {
+		return uniqueErr
+	}
+	return nil
+}
+
+func (r *redisStore) EnqueueMessage(ctx context.Context, queue string, priority float64, message string, options unique.Options) error {
+
+	uniqueFor := options.UniqueFor
+
+	if uniqueFor > 0 {
+		exists, err := r.checkForExistingUniqueMessage(ctx, queue, message)
+		if exists && err == nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := r.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		_, err := pipe.ZAdd(ctx, r.getQueueName(queue), &redis.Z{
+			Score:  priority,
+			Member: message,
+		}).Result()
+		if err != nil {
+			return err
+		}
+		if uniqueFor > 0 {
+			return r.setUniqueKey(ctx, pipe, queue, message, uniqueFor)
+		}
+		return nil
+	})
 
 	return err
 }
@@ -310,9 +353,38 @@ func (r *redisStore) DequeueRetriedMessage(ctx context.Context, priority float64
 	return messages[0], nil
 }
 
-func (r *redisStore) EnqueueMessageNow(ctx context.Context, queue string, message string) error {
+func (r *redisStore) checkForExistingUniqueMessage(ctx context.Context, queue string, message string) (bool, error) {
+	uniqueKey := UniqueHash(queue, message)
+
+	found, err := r.client.Exists(ctx, uniqueKey).Result()
+	return found == 1, err
+}
+
+func (r *redisStore) EnqueueMessageNow(ctx context.Context, queue string, message string, options unique.Options) error {
 	queue = r.namespace + "queue:" + queue
-	_, err := r.client.LPush(ctx, queue, message).Result()
+
+	uniqueFor := options.UniqueFor
+
+	if uniqueFor > 0 {
+		exists, err := r.checkForExistingUniqueMessage(ctx, queue, message)
+		if exists && err == nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	// we want this to be transactionally pipelined so either the key was enqueued with the unique value or it was not.
+	_, err := r.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.LPush(ctx, queue, message)
+
+		if uniqueFor > 0 {
+			return r.setUniqueKey(ctx, pipe, queue, message, uniqueFor)
+		}
+		return nil
+	})
+
 	return err
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -39,15 +39,16 @@ type Retries struct {
 type Heartbeat struct {
 	Identity string `json:"identity"`
 
-	Beat            int64  `json:"beat,string"`
-	Quiet           bool   `json:"quiet,string"`
-	Busy            int    `json:"busy,string"`
-	RttUS           int    `json:"rtt_us,string"`
-	RSS             int64  `json:"rss,string"`
-	Info            string `json:"info"`
-	Pid             int    `json:"pid,string"`
-	ManagerPriority int    `json:"manager_priority,string"`
-	ActiveManager   bool   `json:"active_manager,string"`
+	Beat            int64             `json:"beat,string"`
+	Quiet           bool              `json:"quiet,string"`
+	Busy            int               `json:"busy,string"`
+	RttUS           int               `json:"rtt_us,string"`
+	RSS             int64             `json:"rss,string"`
+	Info            string            `json:"info"`
+	Pid             int               `json:"pid,string"`
+	ManagerPriority int               `json:"manager_priority,string"`
+	ActiveManager   bool              `json:"active_manager,string"`
+	WorkerMessages  map[string]string `json:"worker_messages"`
 
 	Ttl time.Duration
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"github.com/digitalocean/go-workers2/unique"
 	"time"
 )
 
@@ -69,8 +70,8 @@ type Store interface {
 	CreateQueue(ctx context.Context, queue string) error
 	ListMessages(ctx context.Context, queue string) ([]string, error)
 	AcknowledgeMessage(ctx context.Context, queue string, message string) error
-	EnqueueMessage(ctx context.Context, queue string, priority float64, message string) error
-	EnqueueMessageNow(ctx context.Context, queue string, message string) error
+	EnqueueMessage(ctx context.Context, queue string, priority float64, message string, uniqueOptions unique.Options) error
+	EnqueueMessageNow(ctx context.Context, queue string, message string, uniqueOptions unique.Options) error
 	DequeueMessage(ctx context.Context, queue string, inprogressQueue string, timeout time.Duration) (string, error)
 	RequeueMessagesFromInProgressQueue(ctx context.Context, inprogressQueue, queue string) ([]string, error)
 

--- a/unique/options.go
+++ b/unique/options.go
@@ -1,0 +1,24 @@
+package unique
+
+import "time"
+
+type UntilOption string
+
+var UntilStart = UntilOption("start")
+var UntilSuccess = UntilOption("success")
+
+type Options struct {
+	UniqueFor   time.Duration `json:"unique_for,omitempty"`
+	UniqueUntil UntilOption   `json:"unique_until,omitempty"`
+}
+
+func (options Options) IsUnique() bool {
+	return options.UniqueFor > 0
+}
+
+func NewOptions() Options {
+	return Options{
+		UniqueFor:   time.Duration(-1),
+		UniqueUntil: UntilSuccess,
+	}
+}


### PR DESCRIPTION
NOTE: this includes the heartbeat UI fixes from [my other MR](https://github.com/digitalocean/go-workers2/pull/85)

This adds the ability to enqueue unique jobs

It uses a redis transaction in order to ensure that the job was added to the list _and_ the unique key was also added.

1. Set a TTL on the lock.
2. Set logic on the lock (lock until job start or success)