### PR TITLE
Customizable Retry Delay Function

### DIFF
--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -19,7 +19,7 @@ const (
 	RetryTimeFormat = "2006-01-02 15:04:05 MST"
 )
 
-func retryProcessError(queue string, mgr *Manager, message *Msg, err error) error {
+func retryProcessErrorWithDelay(queue string, mgr *Manager, message *Msg, err error, delay func(count int) int) error {
 	if !retry(message) {
 		return err
 	}
@@ -30,7 +30,7 @@ func retryProcessError(queue string, mgr *Manager, message *Msg, err error) erro
 
 		waitDuration := durationToSecondsWithNanoPrecision(
 			time.Duration(
-				secondsToDelay(retryCount),
+				delay(retryCount),
 			) * time.Second,
 		)
 
@@ -50,8 +50,7 @@ func retryProcessError(queue string, mgr *Manager, message *Msg, err error) erro
 	return err
 }
 
-// RetryMiddleware middleware that allows retries for jobs failures
-func RetryMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
+func retryMiddlewareJob(queue string, mgr *Manager, next JobFunc, delayFn func(count int) int) JobFunc {
 	return func(message *Msg) (err error) {
 		defer func() {
 			if e := recover(); e != nil {
@@ -61,7 +60,7 @@ func RetryMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
 				}
 
 				if err != nil {
-					err = retryProcessError(queue, mgr, message, err)
+					err = retryProcessErrorWithDelay(queue, mgr, message, err, delayFn)
 				}
 			}
 
@@ -69,10 +68,23 @@ func RetryMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
 
 		err = next(message)
 		if err != nil {
-			err = retryProcessError(queue, mgr, message, err)
+			err = retryProcessErrorWithDelay(queue, mgr, message, err, delayFn)
 		}
 
 		return
+	}
+}
+
+// RetryMiddleware middleware that allows retries for jobs failures
+func RetryMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
+	return RetryMiddlewareWithDelay(secondsToDelay)(queue, mgr, next)
+}
+
+// RetryMiddlewareWithDelay is like RetryMiddleware but uses a custom function to
+// calculate the retry delay in seconds for a given retry count.
+func RetryMiddlewareWithDelay(delayFn func(count int) int) MiddlewareFunc {
+	return func(queue string, mgr *Manager, next JobFunc) JobFunc {
+		return retryMiddlewareJob(queue, mgr, next, delayFn)
 	}
 }
 

--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -19,7 +19,7 @@ const (
 	RetryTimeFormat = "2006-01-02 15:04:05 MST"
 )
 
-func retryProcessErrorWithDelay(queue string, mgr *Manager, message *Msg, err error, delay func(count int) int) error {
+func retryProcessErrorWithDelay(queue string, mgr *Manager, message *Msg, err error, delay func(count int) time.Duration) error {
 	if !retry(message) {
 		return err
 	}
@@ -28,11 +28,7 @@ func retryProcessErrorWithDelay(queue string, mgr *Manager, message *Msg, err er
 		message.Set("error_message", fmt.Sprintf("%v", err))
 		retryCount := incrementRetry(message)
 
-		waitDuration := durationToSecondsWithNanoPrecision(
-			time.Duration(
-				delay(retryCount),
-			) * time.Second,
-		)
+		waitDuration := durationToSecondsWithNanoPrecision(delay(retryCount))
 
 		err = mgr.opts.store.EnqueueRetriedMessage(context.Background(), nowToSecondsWithNanoPrecision()+waitDuration, message.ToJson())
 
@@ -50,7 +46,7 @@ func retryProcessErrorWithDelay(queue string, mgr *Manager, message *Msg, err er
 	return err
 }
 
-func retryMiddlewareJob(queue string, mgr *Manager, next JobFunc, delayFn func(count int) int) JobFunc {
+func retryMiddlewareJob(queue string, mgr *Manager, next JobFunc, delayFn func(count int) time.Duration) JobFunc {
 	return func(message *Msg) (err error) {
 		defer func() {
 			if e := recover(); e != nil {
@@ -77,12 +73,12 @@ func retryMiddlewareJob(queue string, mgr *Manager, next JobFunc, delayFn func(c
 
 // RetryMiddleware middleware that allows retries for jobs failures
 func RetryMiddleware(queue string, mgr *Manager, next JobFunc) JobFunc {
-	return RetryMiddlewareWithDelay(secondsToDelay)(queue, mgr, next)
+	return RetryMiddlewareWithDelay(defaultDelay)(queue, mgr, next)
 }
 
 // RetryMiddlewareWithDelay is like RetryMiddleware but uses a custom function to
-// calculate the retry delay in seconds for a given retry count.
-func RetryMiddlewareWithDelay(delayFn func(count int) int) MiddlewareFunc {
+// calculate the retry delay for a given retry count (after incrementRetry).
+func RetryMiddlewareWithDelay(delayFn func(count int) time.Duration) MiddlewareFunc {
 	return func(queue string, mgr *Manager, next JobFunc) JobFunc {
 		return retryMiddlewareJob(queue, mgr, next, delayFn)
 	}
@@ -126,7 +122,8 @@ func incrementRetry(message *Msg) (retryCount int) {
 	return
 }
 
-func secondsToDelay(count int) int {
+func defaultDelay(count int) time.Duration {
 	power := math.Pow(float64(count), 4)
-	return int(power) + 15 + (rand.Intn(30) * (count + 1))
+	secs := int(power) + 15 + (rand.Intn(30) * (count + 1))
+	return time.Duration(secs) * time.Second
 }

--- a/middleware_retry_test.go
+++ b/middleware_retry_test.go
@@ -16,7 +16,7 @@ var panickingFunc = func(message *Msg) error {
 }
 
 var wares = NewMiddlewares(RetryMiddleware)
-var waresWithCustomDelay = NewMiddlewares(RetryMiddlewareWithDelay(func(count int) int { return 30 }))
+var waresWithCustomDelay = NewMiddlewares(RetryMiddlewareWithDelay(func(count int) time.Duration { return 30 * time.Second }))
 
 func TestRetryQueue(t *testing.T) {
 	ctx := context.Background()
@@ -280,16 +280,16 @@ func TestRetryMiddlewareWithDelay_EnqueuedScoresAreNowPlusDelay(t *testing.T) {
 	const lowSecs, highSecs = 50, 250
 	var lowCalled, highCalled bool
 
-	delayFn := func(count int) int {
+	delayFn := func(count int) time.Duration {
 		if count == 2 { // retry_count: "1" + 1
 			lowCalled = true
-			return lowSecs
+			return lowSecs * time.Second
 		}
 		if count == 3 { // retry_count: "2" + 1
 			highCalled = true
-			return highSecs
+			return highSecs * time.Second
 		}
-		return lowSecs
+		return lowSecs * time.Second
 	}
 	wares := NewMiddlewares(RetryMiddlewareWithDelay(delayFn))
 
@@ -316,8 +316,8 @@ func TestRetryMiddlewareWithDelay_EnqueuedScoresAreNowPlusDelay(t *testing.T) {
 	assert.Contains(t, scores[0].Member, "delay-gap-1")
 	assert.Contains(t, scores[1].Member, "delay-gap-2")
 
-	lowWait := durationToSecondsWithNanoPrecision(time.Duration(lowSecs) * time.Second)
-	highWait := durationToSecondsWithNanoPrecision(time.Duration(highSecs) * time.Second)
+	lowWait := durationToSecondsWithNanoPrecision(lowSecs * time.Second)
+	highWait := durationToSecondsWithNanoPrecision(highSecs * time.Second)
 
 	mid1 := (before1 + after1) / 2
 	mid2 := (before2 + after2) / 2

--- a/middleware_retry_test.go
+++ b/middleware_retry_test.go
@@ -16,6 +16,7 @@ var panickingFunc = func(message *Msg) error {
 }
 
 var wares = NewMiddlewares(RetryMiddleware)
+var waresWithCustomDelay = NewMiddlewares(RetryMiddlewareWithDelay(func(count int) int { return 30 }))
 
 func TestRetryQueue(t *testing.T) {
 	ctx := context.Background()
@@ -24,15 +25,30 @@ func TestRetryQueue(t *testing.T) {
 	message, _ := NewMsg("{\"jid\":\"2\",\"retry\":true}")
 
 	tests := []struct {
-		name string
-		f    JobFunc
+		name  string
+		wares Middlewares
+		f     JobFunc
 	}{
 		{
-			name: "retry on panic",
-			f:    panickingFunc,
+			name:  "default delay - retry on panic",
+			wares: wares,
+			f:     panickingFunc,
 		},
 		{
-			name: "retry on error",
+			name:  "default delay - retry on error",
+			wares: wares,
+			f: func(m *Msg) error {
+				return errors.New("ERROR")
+			},
+		},
+		{
+			name:  "custom delay - retry on panic",
+			wares: waresWithCustomDelay,
+			f:     panickingFunc,
+		},
+		{
+			name:  "custom delay - retry on error",
+			wares: waresWithCustomDelay,
 			f: func(m *Msg) error {
 				return errors.New("ERROR")
 			},
@@ -48,7 +64,8 @@ func TestRetryQueue(t *testing.T) {
 			// Test panic
 			wares.build("myqueue", mgr, tt.f)(message)
 
-			retries, _ := opts.client.ZRange(ctx, retryQueue(opts.Namespace), 0, 1).Result()
+			retries, err := opts.client.ZRange(ctx, retryQueue(opts.Namespace), 0, 1).Result()
+			assert.NoError(t, err)
 			assert.Len(t, retries, 1)
 			assert.Equal(t, message.ToJson(), retries[0])
 		})
@@ -255,4 +272,63 @@ func TestRetryOnlyToCustomMax(t *testing.T) {
 
 	count, _ := opts.client.ZCard(ctx, retryQueue(opts.Namespace)).Result()
 	assert.Equal(t, int64(0), count)
+}
+
+func TestRetryMiddlewareWithDelay_EnqueuedScoresAreNowPlusDelay(t *testing.T) {
+	ctx := context.Background()
+
+	const lowSecs, highSecs = 50, 250
+	var lowCalled, highCalled bool
+
+	delayFn := func(count int) int {
+		if count == 2 { // retry_count: "1" + 1
+			lowCalled = true
+			return lowSecs
+		}
+		if count == 3 { // retry_count: "2" + 1
+			highCalled = true
+			return highSecs
+		}
+		return lowSecs
+	}
+	wares := NewMiddlewares(RetryMiddlewareWithDelay(delayFn))
+
+	opts, err := SetupDefaultTestOptionsWithNamespace("prod")
+	assert.NoError(t, err)
+
+	mgr := &Manager{opts: opts}
+
+	msg1, _ := NewMsg(`{"jid":"delay-gap-1","retry":true, "retry_count":1}`)
+	before1 := nowToSecondsWithNanoPrecision()
+	wares.build("myqueue", mgr, panickingFunc)(msg1)
+	after1 := nowToSecondsWithNanoPrecision()
+
+	msg2, _ := NewMsg(`{"jid":"delay-gap-2","retry":true, "retry_count":2}`)
+	before2 := nowToSecondsWithNanoPrecision()
+	wares.build("myqueue", mgr, panickingFunc)(msg2)
+	after2 := nowToSecondsWithNanoPrecision()
+
+	scores, err := opts.client.ZRangeWithScores(ctx, retryQueue(opts.Namespace), 0, -1).Result()
+	assert.NoError(t, err)
+	assert.Len(t, scores, 2)
+
+	// ZSET is ordered by score ascending; shorter delay → lower score (earlier run).
+	assert.Contains(t, scores[0].Member, "delay-gap-1")
+	assert.Contains(t, scores[1].Member, "delay-gap-2")
+
+	lowWait := durationToSecondsWithNanoPrecision(time.Duration(lowSecs) * time.Second)
+	highWait := durationToSecondsWithNanoPrecision(time.Duration(highSecs) * time.Second)
+
+	mid1 := (before1 + after1) / 2
+	mid2 := (before2 + after2) / 2
+
+	// EnqueueRetriedMessage uses score = nowToSecondsWithNanoPrecision() + waitDuration.
+	// The real "now" falls between beforeN and afterN; midN estimates it. Expected score is
+	// mid + wait. InDelta tolerance is half the bracket (max error of mid) plus a little
+	// slack for float/Roundtrip through Redis.
+	assert.InDelta(t, mid1+lowWait, scores[0].Score, (after1-before1)/2+0.1)
+	assert.InDelta(t, mid2+highWait, scores[1].Score, (after2-before2)/2+0.1)
+
+	assert.True(t, lowCalled, "delayFunc is not called with retry_count == 2")
+	assert.True(t, highCalled, "delayFunc is not called with retry_count == 3")
 }


### PR DESCRIPTION
## Reason for the change 

In order to add Retry there are two options:
- Use `RetryMiddleware`. This does not allow the user to customize the frequency of retries as uses a fixed `delayToSeconds` function. 
- Implement something like `RetryMiddleware` from scratch. This would require lots of code and duplication of what is happening in the `RetryMiddleware`. 

## What is changed

- This PR is extending the retry middleware with `RetryMiddlewareWithDelay` where the caller can provide their custom delay method. Changes are made so `RetryMiddleware` behaves 100% the same as before so changes are backward compatible.
- Changing the delay function signature so it returns `time.Duration` instead of `int` (seconds) to increase flexibility. The `RetryMiddleware` still uses the same logic and `* time.Second` to keep the returned value in seconds unit.